### PR TITLE
perf: 1.0.10 Phase 3 — measurement harness and hot-path fixes

### DIFF
--- a/Jot/App/Document.swift
+++ b/Jot/App/Document.swift
@@ -32,8 +32,7 @@ class Document: NSDocument {
 		self.addWindowController(windowController)
 
 		if let contentViewController = windowController.contentViewController as? EditorViewController {
-			contentViewController.textView.string = text
-			contentViewController.updateWordCount()
+			contentViewController.loadText(text)
 		}
 	}
 

--- a/Jot/App/Document.swift
+++ b/Jot/App/Document.swift
@@ -6,6 +6,7 @@
 //
 
 import Cocoa
+import os.signpost
 
 class Document: NSDocument {
 	// SAFETY: NSDocument calls read/write overrides on the main thread for
@@ -193,6 +194,10 @@ class Document: NSDocument {
 	/// Internal (not private) so the migration is unit-testable
 	/// with the unsavedStatesFolder override (#135).
 	static func performLegacyMigration() {
+		let signpostID = OSSignpostID(log: PerformanceLog.log)
+		os_signpost(.begin, log: PerformanceLog.log, name: "Legacy Draft Restore", signpostID: signpostID)
+		defer { os_signpost(.end, log: PerformanceLog.log, name: "Legacy Draft Restore", signpostID: signpostID) }
+
 		let fm = FileManager.default
 		guard let folder = unsavedStatesFolder,
 			  let files = try? fm.contentsOfDirectory(at: folder, includingPropertiesForKeys: nil) else { return }

--- a/Jot/Editor/EditorViewController.swift
+++ b/Jot/Editor/EditorViewController.swift
@@ -317,6 +317,19 @@ class EditorViewController: NSViewController, NSTextViewDelegate, TextSettingsDe
 	// chain to NSDocument, whose machinery flushes the live text view in
 	// Document.data(ofType:) -- one save path, one flush point (#118, #125).
 
+	/// The single place that assigns textView.string. Setting the string
+	/// does not fire textDidChange, so the styled-range reset (#139) and
+	/// word-count refresh must happen here — funneled so a new call site
+	/// can't forget them.
+	func loadText(_ text: String) {
+		textView.string = text
+		styledCharacters.removeAll()
+		if currentMode == .markdown {
+			applyStyling()
+		}
+		updateWordCount()
+	}
+
 	/// Called by Document after File > Revert to Saved rereads the file.
 	/// Cancels the pending debounced sync so it can't re-overwrite the
 	/// reverted model, then reloads the editor from the document (#119).
@@ -326,14 +339,7 @@ class EditorViewController: NSViewController, NSTextViewDelegate, TextSettingsDe
 		// Pre-revert undo actions would replay stale edits against the
 		// reverted text
 		textView.undoManager?.removeAllActions()
-		textView.string = text
-		// Setting the string does not fire textDidChange, so reset the
-		// styled-range record here explicitly
-		styledCharacters.removeAll()
-		if currentMode == .markdown {
-			applyStyling()
-		}
-		updateWordCount()
+		loadText(text)
 		// Setting textView.string doesn't fire textDidChange, so the
 		// floating word-count panel needs telling directly
 		NotificationCenter.default.post(name: WordCountPanelController.textDidChangeNotification, object: self)

--- a/Jot/Editor/EditorViewController.swift
+++ b/Jot/Editor/EditorViewController.swift
@@ -32,7 +32,6 @@ class EditorViewController: NSViewController, NSTextViewDelegate, TextSettingsDe
 	override func viewDidLoad() {
 		super.viewDidLoad()
 		textView.delegate = self
-		setupTextView()
 		setupWordCountToggle()
 		loadFontPreferences()
 		updateWordCount()
@@ -157,8 +156,10 @@ class EditorViewController: NSViewController, NSTextViewDelegate, TextSettingsDe
 			let signpostID = OSSignpostID(log: PerformanceLog.log)
 			os_signpost(.begin, log: PerformanceLog.log, name: "Word Count", signpostID: signpostID)
 			defer { os_signpost(.end, log: PerformanceLog.log, name: "Word Count", signpostID: signpostID) }
-			let stats = TextStatistics(text: textView.string)
-			let formattedWordCount = TextStatistics.integerFormatter.string(from: NSNumber(value: stats.wordCount)) ?? ""
+			// Count words only — the label shows one number, so building
+			// all seven statistics here was wasted work (#138)
+			let count = TextStatistics.wordCount(of: textView.string)
+			let formattedWordCount = TextStatistics.integerFormatter.string(from: NSNumber(value: count)) ?? ""
 			wordCountLabel.stringValue = "\(formattedWordCount)"
 		} else {
 			wordCountLabel.stringValue = "Off"
@@ -343,11 +344,6 @@ class EditorViewController: NSViewController, NSTextViewDelegate, TextSettingsDe
 		)
 	}
 
-	// MARK: - Text View Setup
-	private func setupTextView() {
-		updateWordCount()
-	}
-	
 	// MARK: - Lazy Markdown Styling
 
 	private func visibleCharacterRange() -> NSRange? {
@@ -485,12 +481,16 @@ extension EditorViewController {
 			styleCurrentLineAndDeferVisible(in: textView)
 		}
 
-		wordCountUpdateTimer?.invalidate()
-		let wordCountTimer = Timer(timeInterval: 0.5, repeats: false) { [weak self] _ in
-			self?.updateWordCount()
+		// No timer when the toggle is off — the label already says "Off",
+		// so the old fire path was scheduled work with nothing to do (#138)
+		if wordCountToggle.state == .on {
+			wordCountUpdateTimer?.invalidate()
+			let wordCountTimer = Timer(timeInterval: 0.5, repeats: false) { [weak self] _ in
+				self?.updateWordCount()
+			}
+			RunLoop.main.add(wordCountTimer, forMode: .common)
+			wordCountUpdateTimer = wordCountTimer
 		}
-		RunLoop.main.add(wordCountTimer, forMode: .common)
-		wordCountUpdateTimer = wordCountTimer
 
 		NotificationCenter.default.post(name: WordCountPanelController.textDidChangeNotification, object: self)
 	}

--- a/Jot/Editor/EditorViewController.swift
+++ b/Jot/Editor/EditorViewController.swift
@@ -6,6 +6,7 @@
 //
 
 import Cocoa
+import os.signpost
 
 class EditorViewController: NSViewController, NSTextViewDelegate, TextSettingsDelegate {
 	
@@ -132,6 +133,9 @@ class EditorViewController: NSViewController, NSTextViewDelegate, TextSettingsDe
 	// MARK: - Word Count
 	func updateWordCount() {
 		if wordCountToggle.state == .on {
+			let signpostID = OSSignpostID(log: PerformanceLog.log)
+			os_signpost(.begin, log: PerformanceLog.log, name: "Word Count", signpostID: signpostID)
+			defer { os_signpost(.end, log: PerformanceLog.log, name: "Word Count", signpostID: signpostID) }
 			let stats = TextStatistics(text: textView.string)
 			let formattedWordCount = TextStatistics.integerFormatter.string(from: NSNumber(value: stats.wordCount)) ?? ""
 			wordCountLabel.stringValue = "\(formattedWordCount)"
@@ -448,6 +452,9 @@ extension EditorViewController {
 		let syncTimer = Timer(timeInterval: 0.3, repeats: false) { [weak self] _ in
 			guard let self = self,
 				  let document = self.view.window?.windowController?.document as? Document else { return }
+			let signpostID = OSSignpostID(log: PerformanceLog.log)
+			os_signpost(.begin, log: PerformanceLog.log, name: "Document Sync", signpostID: signpostID)
+			defer { os_signpost(.end, log: PerformanceLog.log, name: "Document Sync", signpostID: signpostID) }
 			document.text = self.textView.string
 		}
 		RunLoop.main.add(syncTimer, forMode: .common)

--- a/Jot/Editor/EditorViewController.swift
+++ b/Jot/Editor/EditorViewController.swift
@@ -18,6 +18,12 @@ class EditorViewController: NSViewController, NSTextViewDelegate, TextSettingsDe
 	private var wordCountUpdateTimer: Timer?
 	private var documentSyncTimer: Timer?
 	private var visibleRangeStyleTimer: Timer?
+
+	// Characters styled since the last edit. Scroll passes consult this so
+	// scrolling over already-styled text does no work (#139). Edits reset it
+	// because an edit shifts or invalidates everything after itself; font
+	// changes reset it because recorded styling carries the old font.
+	private var styledCharacters = IndexSet()
 	
 	var selectedFont: NSFont?
 	var selectedFontSize: CGFloat?
@@ -67,11 +73,25 @@ class EditorViewController: NSViewController, NSTextViewDelegate, TextSettingsDe
 		let timer = Timer(timeInterval: 0.1, repeats: false) { [weak self] _ in
 			guard let self = self,
 				  let visibleRange = self.visibleCharacterRange() else { return }
-			let font = self.selectedFont ?? NSFont.systemFont(ofSize: NSFont.systemFontSize)
-			MarkdownProcessor.applyMarkdownStyling(to: self.textView, using: font, range: visibleRange)
+			// Styling is a pure function of the text: if scrolling exposed
+			// nothing new since the last edit, there is nothing to do (#139)
+			if let intRange = Range(visibleRange),
+			   self.styledCharacters.contains(integersIn: intRange) { return }
+			self.applyStyling(range: visibleRange)
 		}
 		RunLoop.main.add(timer, forMode: .common)
 		visibleRangeStyleTimer = timer
+	}
+
+	/// Runs a styling pass and records the covered characters, so scroll
+	/// passes over the same text can be skipped until the next edit.
+	private func applyStyling(range: NSRange? = nil) {
+		let font = selectedFont ?? NSFont.systemFont(ofSize: NSFont.systemFontSize)
+		MarkdownProcessor.applyMarkdownStyling(to: textView, using: font, range: range)
+		let recorded = range ?? NSRange(location: 0, length: (textView.string as NSString).length)
+		if let intRange = Range(recorded) {
+			styledCharacters.insert(integersIn: intRange)
+		}
 	}
 	
 	// MARK: - Text Settings Delegate
@@ -80,6 +100,7 @@ class EditorViewController: NSViewController, NSTextViewDelegate, TextSettingsDe
 		fontConfig.applyFont(font)
 		selectedFont = fontConfig.resolvedFont()
 		textView.font = selectedFont
+		styledCharacters.removeAll()
 	}
 
 	func didSelectFontSize(_ fontSize: CGFloat) {
@@ -88,6 +109,7 @@ class EditorViewController: NSViewController, NSTextViewDelegate, TextSettingsDe
 		selectedFontSize = fontSize
 		selectedFont = fontConfig.resolvedFont()
 		textView.font = selectedFont
+		styledCharacters.removeAll()
 	}
 
 	func loadFontPreferences() {
@@ -103,14 +125,13 @@ class EditorViewController: NSViewController, NSTextViewDelegate, TextSettingsDe
 	
 	@IBAction func toggleEditorMode(_ sender: Any) {
 		currentMode = (currentMode == .markdown) ? .plainText : .markdown
-		
+
 		if currentMode == .markdown {
-			let selectedFont = self.selectedFont ?? NSFont.systemFont(ofSize: NSFont.systemFontSize)
-			MarkdownProcessor.applyMarkdownStyling(to: textView, using: selectedFont)
+			applyStyling()
 		} else {
 			removeMarkdownStyling()
 		}
-		
+
 		updateModeUI()
 	}
 	
@@ -149,8 +170,7 @@ class EditorViewController: NSViewController, NSTextViewDelegate, TextSettingsDe
 	@IBAction func modeChanged(_ sender: NSPopUpButton) {
 		if sender.titleOfSelectedItem == "Markdown" {
 			currentMode = .markdown
-			let selectedFont = self.selectedFont ?? NSFont.systemFont(ofSize: NSFont.systemFontSize)
-			MarkdownProcessor.applyMarkdownStyling(to: textView, using: selectedFont)
+			applyStyling()
 		} else {
 			currentMode = .plainText
 			removeMarkdownStyling()
@@ -160,6 +180,7 @@ class EditorViewController: NSViewController, NSTextViewDelegate, TextSettingsDe
 	
 	func removeMarkdownStyling() {
 		guard let textStorage = textView.textStorage else { return }
+		styledCharacters.removeAll()
 
 		let fullRange = NSRange(location: 0, length: textStorage.length)
 
@@ -258,9 +279,8 @@ class EditorViewController: NSViewController, NSTextViewDelegate, TextSettingsDe
 
 	private func restyleSelectionLineIfMarkdown() {
 		guard currentMode == .markdown else { return }
-		let font = selectedFont ?? NSFont.systemFont(ofSize: NSFont.systemFontSize)
 		let lineRange = (textView.string as NSString).lineRange(for: textView.selectedRange())
-		MarkdownProcessor.applyMarkdownStyling(to: textView, using: font, range: lineRange)
+		applyStyling(range: lineRange)
 	}
 
 	// MARK: - Word Count and Other Actions
@@ -306,9 +326,11 @@ class EditorViewController: NSViewController, NSTextViewDelegate, TextSettingsDe
 		// reverted text
 		textView.undoManager?.removeAllActions()
 		textView.string = text
+		// Setting the string does not fire textDidChange, so reset the
+		// styled-range record here explicitly
+		styledCharacters.removeAll()
 		if currentMode == .markdown {
-			let font = selectedFont ?? NSFont.systemFont(ofSize: NSFont.systemFontSize)
-			MarkdownProcessor.applyMarkdownStyling(to: textView, using: font)
+			applyStyling()
 		}
 		updateWordCount()
 		// Setting textView.string doesn't fire textDidChange, so the
@@ -340,20 +362,16 @@ class EditorViewController: NSViewController, NSTextViewDelegate, TextSettingsDe
 
 	private func styleCurrentLineAndDeferVisible(in textView: NSTextView) {
 		guard let selectedRange = textView.selectedRanges.first?.rangeValue else { return }
-		let font = selectedFont ?? NSFont.systemFont(ofSize: NSFont.systemFontSize)
 
 		// Immediately style the line the user is editing
 		let currentLineRange = (textView.string as NSString).lineRange(for: selectedRange)
-		MarkdownProcessor.applyMarkdownStyling(to: textView, using: font, range: currentLineRange)
+		applyStyling(range: currentLineRange)
 
-		// Debounce a visible-range restyle so surrounding context catches up.
-		// nonisolated(unsafe) is safe here only because NSFont is immutable;
-		// don't copy this pattern for mutable reference types.
-		nonisolated(unsafe) let sendableFont = font
+		// Debounce a visible-range restyle so surrounding context catches up
 		visibleRangeStyleTimer?.invalidate()
 		let timer = Timer(timeInterval: 0.3, repeats: false) { [weak self] _ in
 			guard let self = self, let visibleRange = self.visibleCharacterRange() else { return }
-			MarkdownProcessor.applyMarkdownStyling(to: self.textView, using: sendableFont, range: visibleRange)
+			self.applyStyling(range: visibleRange)
 		}
 		RunLoop.main.add(timer, forMode: .common)
 		visibleRangeStyleTimer = timer
@@ -460,6 +478,9 @@ extension EditorViewController {
 		RunLoop.main.add(syncTimer, forMode: .common)
 		documentSyncTimer = syncTimer
 
+		// An edit shifts or invalidates everything after itself — forget
+		// what was styled before restyling anything (#139)
+		styledCharacters.removeAll()
 		if currentMode == .markdown {
 			styleCurrentLineAndDeferVisible(in: textView)
 		}

--- a/Jot/Markdown/MarkdownPreviewViewController.swift
+++ b/Jot/Markdown/MarkdownPreviewViewController.swift
@@ -8,6 +8,7 @@
 import Cocoa
 import Down
 import WebKit
+import os.signpost
 
 class MarkdownPreviewViewController: NSViewController, @preconcurrency WKNavigationDelegate {
 
@@ -36,6 +37,10 @@ class MarkdownPreviewViewController: NSViewController, @preconcurrency WKNavigat
 	}
 
 	func renderMarkdown(markdown: String) {
+		let signpostID = OSSignpostID(log: PerformanceLog.log)
+		os_signpost(.begin, log: PerformanceLog.log, name: "Preview Render", signpostID: signpostID,
+					"%d chars", markdown.utf16.count)
+		defer { os_signpost(.end, log: PerformanceLog.log, name: "Preview Render", signpostID: signpostID) }
 		let down = Down(markdownString: markdown)
 		let bodyHTML = (try? down.toHTML()) ?? ""
 

--- a/Jot/Markdown/MarkdownProcessor.swift
+++ b/Jot/Markdown/MarkdownProcessor.swift
@@ -56,7 +56,11 @@ enum MarkdownProcessor {
 
 	static func applyMarkdownStyling(to textView: NSTextView, using selectedFont: NSFont, range: NSRange? = nil) {
 		guard let textStorage = textView.textStorage else { return }
-		let stylingRange = range ?? NSRange(location: 0, length: textStorage.length)
+		let requestedRange = range ?? NSRange(location: 0, length: textStorage.length)
+		// Expand to whole lines so line-anchored patterns (headings, lists)
+		// and single-line spans (inline code) are never cut mid-match at the
+		// range edges.
+		let stylingRange = (textStorage.string as NSString).lineRange(for: requestedRange)
 
 		let signpostID = OSSignpostID(log: PerformanceLog.log)
 		os_signpost(.begin, log: PerformanceLog.log, name: "Markdown Styling", signpostID: signpostID,
@@ -66,13 +70,12 @@ enum MarkdownProcessor {
 		textStorage.beginEditing()
 
 		// Reset pass — removes stale attributes so deleted syntax doesn't leave
-		// behind bold, colour, background, or strikethrough from a previous pass.
-		// Background is always cleared on the full document because code blocks
-		// can start before the dirty range.
-		let fullRange = NSRange(location: 0, length: textStorage.length)
+		// behind bold, colour, background, or strikethrough from a previous
+		// pass. All resets are bounded to the styling range: per-keystroke
+		// passes must not do document-sized attribute churn (#123).
 		textStorage.addAttribute(.font, value: selectedFont, range: stylingRange)
 		textStorage.addAttribute(.foregroundColor, value: NSColor.labelColor, range: stylingRange)
-		textStorage.removeAttribute(.backgroundColor, range: fullRange)
+		textStorage.removeAttribute(.backgroundColor, range: stylingRange)
 		textStorage.removeAttribute(.strikethroughStyle, range: stylingRange)
 		textStorage.removeAttribute(.underlineStyle, range: stylingRange)
 		textStorage.removeAttribute(.link, range: stylingRange)
@@ -142,18 +145,24 @@ enum MarkdownProcessor {
 			.backgroundColor: codeBackground,
 		]
 
-		// Code blocks can start before the dirty range, so both inline and
-		// block code scan the full document. Backgrounds are already cleared
-		// in the reset pass above.
-		let fullRange = NSRange(location: 0, length: textStorage.length)
-
-		inlineCodeRegex.enumerateMatches(in: textStorage.string, options: [], range: fullRange) { match, _, _ in
+		// Inline code spans are single-line and `range` is line-aligned, so
+		// the bounded scan cannot cut a span in half.
+		inlineCodeRegex.enumerateMatches(in: textStorage.string, options: [], range: range) { match, _, _ in
 			guard let codeRange = match?.range(at: 1) else { return }
 			textStorage.addAttributes(codeAttributes, range: codeRange)
 		}
 
+		// Fenced blocks can open before the styling range and close after it,
+		// so the scan stays full-document (a cheap literal search for ```).
+		// Attribute application is bounded to blocks that intersect the
+		// styling range — backgrounds elsewhere are still valid from the pass
+		// that styled them. Known limit: deleting a fence delimiter leaves the
+		// old background outside the styling range until a wider pass (scroll,
+		// mode toggle) covers it (#123).
+		let fullRange = NSRange(location: 0, length: textStorage.length)
 		codeBlockRegex.enumerateMatches(in: textStorage.string, options: [], range: fullRange) { match, _, _ in
-			guard let matchRange = match?.range else { return }
+			guard let matchRange = match?.range,
+				  NSIntersectionRange(matchRange, range).length > 0 else { return }
 			textStorage.addAttributes(codeAttributes, range: matchRange)
 		}
 	}

--- a/Jot/Markdown/MarkdownProcessor.swift
+++ b/Jot/Markdown/MarkdownProcessor.swift
@@ -6,6 +6,7 @@
 //
 
 import Cocoa
+import os.signpost
 
 // Caseless enum acts as a namespace — prevents instantiation.
 @MainActor
@@ -56,6 +57,11 @@ enum MarkdownProcessor {
 	static func applyMarkdownStyling(to textView: NSTextView, using selectedFont: NSFont, range: NSRange? = nil) {
 		guard let textStorage = textView.textStorage else { return }
 		let stylingRange = range ?? NSRange(location: 0, length: textStorage.length)
+
+		let signpostID = OSSignpostID(log: PerformanceLog.log)
+		os_signpost(.begin, log: PerformanceLog.log, name: "Markdown Styling", signpostID: signpostID,
+					"%d of %d chars", stylingRange.length, textStorage.length)
+		defer { os_signpost(.end, log: PerformanceLog.log, name: "Markdown Styling", signpostID: signpostID) }
 
 		textStorage.beginEditing()
 

--- a/Jot/Markdown/MarkdownProcessor.swift
+++ b/Jot/Markdown/MarkdownProcessor.swift
@@ -159,12 +159,14 @@ enum MarkdownProcessor {
 		}
 
 		// Fenced blocks can open before the styling range and close after it,
-		// so the scan stays full-document (a cheap literal search for ```).
-		// Attribute application is bounded to blocks that intersect the
-		// styling range — backgrounds elsewhere are still valid from the pass
-		// that styled them. Known limit: deleting a fence delimiter leaves the
-		// old background outside the styling range until a wider pass (scroll,
-		// mode toggle) covers it (#123).
+		// so the scan stays full-document. This is the remaining per-keystroke
+		// document-scale cost: the regex enumerates every fenced block in the
+		// document even though attribute writes are bounded to blocks that
+		// intersect the styling range (backgrounds elsewhere are still valid
+		// from the pass that styled them). Caching fence positions would
+		// remove it, at real complexity cost. Known limit: deleting a fence
+		// delimiter leaves the old background outside the styling range until
+		// a wider pass (scroll, mode toggle) covers it (#123).
 		let fullRange = NSRange(location: 0, length: textStorage.length)
 		codeBlockRegex.enumerateMatches(in: string, options: [], range: fullRange) { match, _, _ in
 			guard let matchRange = match?.range,

--- a/Jot/Markdown/MarkdownProcessor.swift
+++ b/Jot/Markdown/MarkdownProcessor.swift
@@ -56,11 +56,17 @@ enum MarkdownProcessor {
 
 	static func applyMarkdownStyling(to textView: NSTextView, using selectedFont: NSFont, range: NSRange? = nil) {
 		guard let textStorage = textView.textStorage else { return }
+		// One string snapshot for the whole pass. Bridging the mutable
+		// backing store into Swift is an O(document) copy, so every
+		// textStorage.string access in a helper was a full-document copy —
+		// ~13 per pass (#141). The pass only mutates attributes, never
+		// characters, so a single snapshot stays valid throughout.
+		let string = textStorage.string
 		let requestedRange = range ?? NSRange(location: 0, length: textStorage.length)
 		// Expand to whole lines so line-anchored patterns (headings, lists)
 		// and single-line spans (inline code) are never cut mid-match at the
 		// range edges.
-		let stylingRange = (textStorage.string as NSString).lineRange(for: requestedRange)
+		let stylingRange = (string as NSString).lineRange(for: requestedRange)
 
 		let signpostID = OSSignpostID(log: PerformanceLog.log)
 		os_signpost(.begin, log: PerformanceLog.log, name: "Markdown Styling", signpostID: signpostID,
@@ -88,27 +94,27 @@ enum MarkdownProcessor {
 		// - Horizontal rules AFTER bold/italic because `***` is valid
 		//   bold-italic syntax. If horizontal rules ran first, `***text***`
 		//   would be styled as a rule instead of bold-italic.
-		applyHeadings(to: textStorage, using: selectedFont, range: stylingRange)
-		applyBoldItalic(to: textStorage, range: stylingRange)
-		applyBold(to: textStorage, range: stylingRange)
-		applyItalic(to: textStorage, range: stylingRange)
-		applyCode(to: textStorage, range: stylingRange)
-		applyLinks(to: textStorage, range: stylingRange)
-		applyStrikethrough(to: textStorage, range: stylingRange)
-		applyListStyling(to: textStorage, range: stylingRange)
-		applyBlockquotes(to: textStorage, range: stylingRange)
-		applyHorizontalRules(to: textStorage, range: stylingRange)
-		applyTables(to: textStorage, using: selectedFont, range: stylingRange)
+		applyHeadings(to: textStorage, in: string, using: selectedFont, range: stylingRange)
+		applyBoldItalic(to: textStorage, in: string, range: stylingRange)
+		applyBold(to: textStorage, in: string, range: stylingRange)
+		applyItalic(to: textStorage, in: string, range: stylingRange)
+		applyCode(to: textStorage, in: string, range: stylingRange)
+		applyLinks(to: textStorage, in: string, range: stylingRange)
+		applyStrikethrough(to: textStorage, in: string, range: stylingRange)
+		applyListStyling(to: textStorage, in: string, range: stylingRange)
+		applyBlockquotes(to: textStorage, in: string, range: stylingRange)
+		applyHorizontalRules(to: textStorage, in: string, range: stylingRange)
+		applyTables(to: textStorage, in: string, using: selectedFont, range: stylingRange)
 
 		textStorage.endEditing()
 	}
 
 	// MARK: - Headings
 
-	private static func applyHeadings(to textStorage: NSTextStorage, using selectedFont: NSFont, range: NSRange) {
+	private static func applyHeadings(to textStorage: NSTextStorage, in string: String, using selectedFont: NSFont, range: NSRange) {
 		let boldFont = NSFontManager.shared.convert(selectedFont, toHaveTrait: .boldFontMask)
 
-		headingRegex.enumerateMatches(in: textStorage.string, options: [], range: range) { match, _, _ in
+		headingRegex.enumerateMatches(in: string, options: [], range: range) { match, _, _ in
 			guard let symbolRange = match?.range(at: 1),
 				  let textRange   = match?.range(at: 2) else { return }
 
@@ -119,27 +125,27 @@ enum MarkdownProcessor {
 
 	// MARK: - Bold + Italic
 
-	private static func applyBoldItalic(to textStorage: NSTextStorage, range: NSRange) {
-		applyInlineStyle(with: boldItalicRegex, traits: [.boldFontMask, .italicFontMask], symbolLength: 3, in: textStorage, range: range)
+	private static func applyBoldItalic(to textStorage: NSTextStorage, in string: String, range: NSRange) {
+		applyInlineStyle(with: boldItalicRegex, traits: [.boldFontMask, .italicFontMask], symbolLength: 3, in: textStorage, string: string, range: range)
 	}
 
 	// MARK: - Bold
 
-	private static func applyBold(to textStorage: NSTextStorage, range: NSRange) {
-		applyInlineStyle(with: boldAsteriskRegex,   traits: .boldFontMask, symbolLength: 2, in: textStorage, range: range)
-		applyInlineStyle(with: boldUnderscoreRegex, traits: .boldFontMask, symbolLength: 2, in: textStorage, range: range)
+	private static func applyBold(to textStorage: NSTextStorage, in string: String, range: NSRange) {
+		applyInlineStyle(with: boldAsteriskRegex,   traits: .boldFontMask, symbolLength: 2, in: textStorage, string: string, range: range)
+		applyInlineStyle(with: boldUnderscoreRegex, traits: .boldFontMask, symbolLength: 2, in: textStorage, string: string, range: range)
 	}
 
 	// MARK: - Italic
 
-	private static func applyItalic(to textStorage: NSTextStorage, range: NSRange) {
-		applyInlineStyle(with: italicAsteriskRegex,   traits: .italicFontMask, symbolLength: 1, in: textStorage, range: range)
-		applyInlineStyle(with: italicUnderscoreRegex, traits: .italicFontMask, symbolLength: 1, in: textStorage, range: range)
+	private static func applyItalic(to textStorage: NSTextStorage, in string: String, range: NSRange) {
+		applyInlineStyle(with: italicAsteriskRegex,   traits: .italicFontMask, symbolLength: 1, in: textStorage, string: string, range: range)
+		applyInlineStyle(with: italicUnderscoreRegex, traits: .italicFontMask, symbolLength: 1, in: textStorage, string: string, range: range)
 	}
 
 	// MARK: - Code
 
-	private static func applyCode(to textStorage: NSTextStorage, range: NSRange) {
+	private static func applyCode(to textStorage: NSTextStorage, in string: String, range: NSRange) {
 		let codeAttributes: [NSAttributedString.Key: Any] = [
 			.foregroundColor: NSColor.secondaryLabelColor,
 			.backgroundColor: codeBackground,
@@ -147,7 +153,7 @@ enum MarkdownProcessor {
 
 		// Inline code spans are single-line and `range` is line-aligned, so
 		// the bounded scan cannot cut a span in half.
-		inlineCodeRegex.enumerateMatches(in: textStorage.string, options: [], range: range) { match, _, _ in
+		inlineCodeRegex.enumerateMatches(in: string, options: [], range: range) { match, _, _ in
 			guard let codeRange = match?.range(at: 1) else { return }
 			textStorage.addAttributes(codeAttributes, range: codeRange)
 		}
@@ -160,7 +166,7 @@ enum MarkdownProcessor {
 		// old background outside the styling range until a wider pass (scroll,
 		// mode toggle) covers it (#123).
 		let fullRange = NSRange(location: 0, length: textStorage.length)
-		codeBlockRegex.enumerateMatches(in: textStorage.string, options: [], range: fullRange) { match, _, _ in
+		codeBlockRegex.enumerateMatches(in: string, options: [], range: fullRange) { match, _, _ in
 			guard let matchRange = match?.range,
 				  NSIntersectionRange(matchRange, range).length > 0 else { return }
 			textStorage.addAttributes(codeAttributes, range: matchRange)
@@ -169,8 +175,8 @@ enum MarkdownProcessor {
 
 	// MARK: - Links
 
-	private static func applyLinks(to textStorage: NSTextStorage, range: NSRange) {
-		linkRegex.enumerateMatches(in: textStorage.string, options: [], range: range) { match, _, _ in
+	private static func applyLinks(to textStorage: NSTextStorage, in string: String, range: NSRange) {
+		linkRegex.enumerateMatches(in: string, options: [], range: range) { match, _, _ in
 			guard let matchRange    = match?.range,
 				  let linkTextRange = match?.range(at: 1) else { return }
 
@@ -188,8 +194,8 @@ enum MarkdownProcessor {
 
 	// MARK: - Strikethrough
 
-	private static func applyStrikethrough(to textStorage: NSTextStorage, range: NSRange) {
-		strikethroughRegex.enumerateMatches(in: textStorage.string, options: [], range: range) { match, _, _ in
+	private static func applyStrikethrough(to textStorage: NSTextStorage, in string: String, range: NSRange) {
+		strikethroughRegex.enumerateMatches(in: string, options: [], range: range) { match, _, _ in
 			guard let matchRange = match?.range,
 				  let textRange  = match?.range(at: 1) else { return }
 
@@ -206,10 +212,10 @@ enum MarkdownProcessor {
 
 	// MARK: - Lists
 
-	private static func applyListStyling(to textStorage: NSTextStorage, range: NSRange) {
+	private static func applyListStyling(to textStorage: NSTextStorage, in string: String, range: NSRange) {
 		let markerAttributes: [NSAttributedString.Key: Any] = [.foregroundColor: NSColor.secondaryLabelColor]
 		for regex in [unorderedListRegex, orderedListRegex] {
-			regex.enumerateMatches(in: textStorage.string, options: [], range: range) { match, _, _ in
+			regex.enumerateMatches(in: string, options: [], range: range) { match, _, _ in
 				guard let matchRange = match?.range else { return }
 				textStorage.addAttributes(markerAttributes, range: matchRange)
 			}
@@ -218,8 +224,8 @@ enum MarkdownProcessor {
 
 	// MARK: - Blockquotes (new)
 
-	private static func applyBlockquotes(to textStorage: NSTextStorage, range: NSRange) {
-		blockquoteRegex.enumerateMatches(in: textStorage.string, options: [], range: range) { match, _, _ in
+	private static func applyBlockquotes(to textStorage: NSTextStorage, in string: String, range: NSRange) {
+		blockquoteRegex.enumerateMatches(in: string, options: [], range: range) { match, _, _ in
 			guard let prefixRange  = match?.range(at: 1),
 				  let contentRange = match?.range(at: 2) else { return }
 
@@ -230,8 +236,8 @@ enum MarkdownProcessor {
 
 	// MARK: - Horizontal rules (new)
 
-	private static func applyHorizontalRules(to textStorage: NSTextStorage, range: NSRange) {
-		horizontalRuleRegex.enumerateMatches(in: textStorage.string, options: [], range: range) { match, _, _ in
+	private static func applyHorizontalRules(to textStorage: NSTextStorage, in string: String, range: NSRange) {
+		horizontalRuleRegex.enumerateMatches(in: string, options: [], range: range) { match, _, _ in
 			guard let matchRange = match?.range else { return }
 			textStorage.addAttribute(.foregroundColor, value: NSColor.tertiaryLabelColor, range: matchRange)
 		}
@@ -239,9 +245,8 @@ enum MarkdownProcessor {
 
 	// MARK: - Tables
 
-	private static func applyTables(to textStorage: NSTextStorage, using selectedFont: NSFont, range: NSRange) {
+	private static func applyTables(to textStorage: NSTextStorage, in string: String, using selectedFont: NSFont, range: NSRange) {
 		let boldFont = NSFontManager.shared.convert(selectedFont, toHaveTrait: .boldFontMask)
-		let string = textStorage.string
 
 		// Find all table rows (lines with pipes)
 		tableRowRegex.enumerateMatches(in: string, options: [], range: range) { match, _, _ in
@@ -275,11 +280,12 @@ enum MarkdownProcessor {
 		traits: NSFontTraitMask,
 		symbolLength: Int,
 		in textStorage: NSTextStorage,
+		string: String,
 		range: NSRange
 	) {
 		let fontManager = NSFontManager.shared
 
-		regex.enumerateMatches(in: textStorage.string, options: [], range: range) { match, _, _ in
+		regex.enumerateMatches(in: string, options: [], range: range) { match, _, _ in
 			guard let matchRange = match?.range,
 				  let textRange  = match?.range(at: 1) else { return }
 

--- a/Jot/Models/PerformanceLog.swift
+++ b/Jot/Models/PerformanceLog.swift
@@ -1,0 +1,15 @@
+//
+//  PerformanceLog.swift
+//  Jot
+//
+//  Shared signpost log for the app's hot paths (#142). The markers show up
+//  by name in Instruments under "Points of Interest" — see docs/PERFORMANCE.md
+//  for the profiling playbook.
+//
+
+import Foundation
+import os.signpost
+
+enum PerformanceLog {
+    static let log = OSLog(subsystem: "com.brian.jot", category: .pointsOfInterest)
+}

--- a/Jot/Models/TextStatistics.swift
+++ b/Jot/Models/TextStatistics.swift
@@ -18,6 +18,16 @@ struct TextStatistics {
         return formatter
     }()
 
+    // nonisolated(unsafe): ByteCountFormatter lacks Foundation's Sendable
+    // annotation (NumberFormatter above has it). Safe here because every
+    // TextStatistics user runs on the main thread; revisit if that changes.
+    nonisolated(unsafe) private static let byteFormatter: ByteCountFormatter = {
+        let formatter = ByteCountFormatter()
+        formatter.allowedUnits = [.useBytes, .useKB, .useMB]
+        formatter.countStyle = .file
+        return formatter
+    }()
+
     let wordCount: Int
     let characterCount: Int
     let characterCountNoSpaces: Int
@@ -26,51 +36,107 @@ struct TextStatistics {
     let readingTimeSeconds: Int
     let fileSizeString: String
 
-    init(text: String) {
-        wordCount = text.components(separatedBy: .whitespacesAndNewlines)
-            .filter { !$0.isEmpty }
-            .count
+    // The tallies iterate unicode scalars and test raw values: Character
+    // iteration pays for grapheme segmentation (~70 ms per MB even with -O,
+    // measured for #138) and the CharacterSet/ICU predicates are similarly
+    // slow. These two switches are the members of CharacterSet's
+    // whitespacesAndNewlines and newlines sets.
 
+    private static func isWhitespaceScalar(_ value: UInt32) -> Bool {
+        switch value {
+        case 0x09...0x0D, 0x20, 0x85, 0xA0, 0x1680,
+             0x2000...0x200A, 0x2028, 0x2029, 0x202F, 0x205F, 0x3000:
+            return true
+        default:
+            return false
+        }
+    }
+
+    private static func isNewlineScalar(_ value: UInt32) -> Bool {
+        switch value {
+        case 0x0A...0x0D, 0x85, 0x2028, 0x2029:
+            return true
+        default:
+            return false
+        }
+    }
+
+    /// Words are runs of non-whitespace, the same definition the full
+    /// statistics use. The editor's word-count label calls this instead of
+    /// building all seven statistics just to display one number (#138).
+    static func wordCount(of text: String) -> Int {
+        var count = 0
+        var previousWasWhitespace = true
+        for scalar in text.unicodeScalars {
+            if isWhitespaceScalar(scalar.value) {
+                previousWasWhitespace = true
+            } else {
+                if previousWasWhitespace { count += 1 }
+                previousWasWhitespace = false
+            }
+        }
+        return count
+    }
+
+    init(text: String) {
+        wordCount = TextStatistics.wordCount(of: text)
         characterCount = text.count
 
-        characterCountNoSpaces = text.filter { !$0.isWhitespace }.count
+        // Everything else in one scalar pass. The old implementation made ~6
+        // full passes and materialized every word and line as its own String
+        // — tens of MB of allocator churn per keystroke pause on large
+        // documents (#138). A CRLF pair is one logical newline and one
+        // Character, so it must count once, not twice.
+        var whitespaceCharacters = 0
+        var lineTotal = 0
+        var paragraphTotal = 0
 
-        lineCount = text.components(separatedBy: .newlines)
-            .filter { !$0.isEmpty }
-            .count
+        // Paragraph rules (same results as the old trim-then-scan version):
+        // a break is a run of 2+ newlines, but breaks only count once real
+        // (non-whitespace) content follows — pending breaks at the very
+        // start or end of the text are what trimming used to discard.
+        var pendingBreaks = 0
+        var newlineRun = 0
+        var atLineStart = true
+        var previousValue: UInt32 = 0
 
-        // Paragraphs: blocks of text separated by one or more blank lines.
-        // Any run of 2+ consecutive newlines counts as one paragraph break.
-        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-        if trimmed.isEmpty {
-            paragraphCount = 0
-        } else {
-            var count = 1
-            var previousWasNewline = false
-            var inBreak = false
-            for char in trimmed {
-                if char.isNewline {
-                    if previousWasNewline && !inBreak {
-                        count += 1
-                        inBreak = true
-                    }
-                    previousWasNewline = true
+        for scalar in text.unicodeScalars {
+            let value = scalar.value
+            let crlfContinuation = (value == 0x0A && previousValue == 0x0D)
+            previousValue = value
+
+            if TextStatistics.isWhitespaceScalar(value) {
+                if !crlfContinuation { whitespaceCharacters += 1 }
+            } else {
+                if paragraphTotal == 0 {
+                    paragraphTotal = 1
                 } else {
-                    previousWasNewline = false
-                    inBreak = false
+                    paragraphTotal += pendingBreaks
                 }
+                pendingBreaks = 0
             }
-            paragraphCount = count
+
+            if TextStatistics.isNewlineScalar(value) {
+                if !crlfContinuation {
+                    newlineRun += 1
+                    if newlineRun == 2 { pendingBreaks += 1 }
+                    atLineStart = true
+                }
+            } else {
+                newlineRun = 0
+                if atLineStart { lineTotal += 1 }
+                atLineStart = false
+            }
         }
+
+        characterCountNoSpaces = characterCount - whitespaceCharacters
+        lineCount = lineTotal
+        paragraphCount = paragraphTotal
 
         // Reading time at ~250 words per minute
         readingTimeSeconds = wordCount > 0 ? max(1, (wordCount * 60) / 250) : 0
 
-        let byteCount = text.data(using: .utf8)?.count ?? 0
-        let formatter = ByteCountFormatter()
-        formatter.allowedUnits = [.useBytes, .useKB, .useMB]
-        formatter.countStyle = .file
-        fileSizeString = formatter.string(fromByteCount: Int64(byteCount))
+        fileSizeString = TextStatistics.byteFormatter.string(fromByteCount: Int64(text.utf8.count))
     }
 
     var readingTimeString: String {

--- a/Jot/Models/TextStatistics.swift
+++ b/Jot/Models/TextStatistics.swift
@@ -18,16 +18,6 @@ struct TextStatistics {
         return formatter
     }()
 
-    // nonisolated(unsafe): ByteCountFormatter lacks Foundation's Sendable
-    // annotation (NumberFormatter above has it). Safe here because every
-    // TextStatistics user runs on the main thread; revisit if that changes.
-    nonisolated(unsafe) private static let byteFormatter: ByteCountFormatter = {
-        let formatter = ByteCountFormatter()
-        formatter.allowedUnits = [.useBytes, .useKB, .useMB]
-        formatter.countStyle = .file
-        return formatter
-    }()
-
     let wordCount: Int
     let characterCount: Int
     let characterCountNoSpaces: Int
@@ -39,9 +29,18 @@ struct TextStatistics {
     // The tallies iterate unicode scalars and test raw values: Character
     // iteration pays for grapheme segmentation (~70 ms per MB even with -O,
     // measured for #138) and the CharacterSet/ICU predicates are similarly
-    // slow. These two switches are the members of CharacterSet's
-    // whitespacesAndNewlines and newlines sets.
+    // slow.
+    //
+    // Two different whitespace sets, faithful to the pre-1.0.10 behavior:
+    // word and paragraph logic follows CharacterSet.whitespacesAndNewlines,
+    // which includes U+200B ZERO WIDTH SPACE (a documented CharacterSet
+    // quirk — Unicode's White_Space property excludes it); the character
+    // tallies follow White_Space, matching the old Character.isWhitespace
+    // counting. Net effect: ZWSP separates words but counts as a non-space
+    // character, exactly as shipped in 1.0.9.
 
+    /// Unicode White_Space scalars (the members of CharacterSet.whitespaces
+    /// plus newlines, minus U+200B).
     private static func isWhitespaceScalar(_ value: UInt32) -> Bool {
         switch value {
         case 0x09...0x0D, 0x20, 0x85, 0xA0, 0x1680,
@@ -52,6 +51,12 @@ struct TextStatistics {
         }
     }
 
+    /// CharacterSet.whitespacesAndNewlines membership, ZWSP included.
+    private static func isWordSeparatorScalar(_ value: UInt32) -> Bool {
+        return value == 0x200B || isWhitespaceScalar(value)
+    }
+
+    /// The members of CharacterSet.newlines (verified exhaustively in review).
     private static func isNewlineScalar(_ value: UInt32) -> Bool {
         switch value {
         case 0x0A...0x0D, 0x85, 0x2028, 0x2029:
@@ -66,13 +71,13 @@ struct TextStatistics {
     /// building all seven statistics just to display one number (#138).
     static func wordCount(of text: String) -> Int {
         var count = 0
-        var previousWasWhitespace = true
+        var previousWasSeparator = true
         for scalar in text.unicodeScalars {
-            if isWhitespaceScalar(scalar.value) {
-                previousWasWhitespace = true
+            if isWordSeparatorScalar(scalar.value) {
+                previousWasSeparator = true
             } else {
-                if previousWasWhitespace { count += 1 }
-                previousWasWhitespace = false
+                if previousWasSeparator { count += 1 }
+                previousWasSeparator = false
             }
         }
         return count
@@ -105,9 +110,13 @@ struct TextStatistics {
             let crlfContinuation = (value == 0x0A && previousValue == 0x0D)
             previousValue = value
 
-            if TextStatistics.isWhitespaceScalar(value) {
-                if !crlfContinuation { whitespaceCharacters += 1 }
-            } else {
+            if TextStatistics.isWhitespaceScalar(value) && !crlfContinuation {
+                whitespaceCharacters += 1
+            }
+
+            // Word separators (including ZWSP) are not paragraph content —
+            // this mirrors the old code trimming whitespacesAndNewlines
+            if !TextStatistics.isWordSeparatorScalar(value) {
                 if paragraphTotal == 0 {
                     paragraphTotal = 1
                 } else {
@@ -129,6 +138,11 @@ struct TextStatistics {
             }
         }
 
+        // Deliberate correction from the old text.filter-based count: filter
+        // rebuilt a string and re-ran grapheme segmentation, so removing a
+        // whitespace character could merge its neighbors into one grapheme
+        // ("a" + newline + combining accent + "b" counted 2, not 3). This
+        // subtraction keeps the original text's segmentation.
         characterCountNoSpaces = characterCount - whitespaceCharacters
         lineCount = lineTotal
         paragraphCount = paragraphTotal
@@ -136,7 +150,13 @@ struct TextStatistics {
         // Reading time at ~250 words per minute
         readingTimeSeconds = wordCount > 0 ? max(1, (wordCount * 60) / 250) : 0
 
-        fileSizeString = TextStatistics.byteFormatter.string(fromByteCount: Int64(text.utf8.count))
+        // Local formatter, not static: ByteCountFormatter has no Sendable
+        // annotation or thread-safety guarantee, and one small allocation is
+        // noise next to the document scan above.
+        let byteFormatter = ByteCountFormatter()
+        byteFormatter.allowedUnits = [.useBytes, .useKB, .useMB]
+        byteFormatter.countStyle = .file
+        fileSizeString = byteFormatter.string(fromByteCount: Int64(text.utf8.count))
     }
 
     var readingTimeString: String {

--- a/JotTests/MarkdownProcessorTests.swift
+++ b/JotTests/MarkdownProcessorTests.swift
@@ -529,6 +529,41 @@ final class MarkdownProcessorTests: XCTestCase {
 
     // MARK: - Mode switching (#37)
 
+    // MARK: - Ranged passes stay bounded (#123)
+
+    func testRangedPassInsideCodeBlockKeepsBackground() {
+        let markdown = "```\ncode line\n```"
+        _ = applyAndGetStorage(markdown)
+        // Restyle just the "code line" line, as a keystroke inside it would
+        let lineRange = (markdown as NSString).range(of: "code line")
+        MarkdownProcessor.applyMarkdownStyling(to: textView, using: font, range: lineRange)
+
+        XCTAssertNotNil(textView.textStorage!.attribute(.backgroundColor, at: 5, effectiveRange: nil),
+                        "a bounded pass inside a fenced block must re-apply the block background")
+    }
+
+    func testRangedPassLeavesDistantStylingAlone() {
+        let markdown = "**bold**\n\n```\ncode\n```"
+        _ = applyAndGetStorage(markdown)
+        // Restyle only the first line; the code block further down must keep
+        // its background even though the pass never touched it
+        MarkdownProcessor.applyMarkdownStyling(to: textView, using: font, range: NSRange(location: 0, length: 8))
+
+        let codeLocation = (markdown as NSString).range(of: "code\n").location
+        XCTAssertNotNil(textView.textStorage!.attribute(.backgroundColor, at: codeLocation, effectiveRange: nil),
+                        "a pass over line 1 must not strip the code background further down")
+        XCTAssertTrue(hasTrait(textView.textStorage!, location: 2, trait: .boldFontMask))
+    }
+
+    func testRangedPassExpandsToWholeLine() {
+        textView.string = "# Heading line"
+        // Deliberately mid-line: two characters inside the heading text
+        MarkdownProcessor.applyMarkdownStyling(to: textView, using: font, range: NSRange(location: 5, length: 2))
+
+        XCTAssertTrue(hasTrait(textView.textStorage!, location: 3, trait: .boldFontMask),
+                      "the pass must expand to line boundaries so line-anchored patterns match")
+    }
+
     func testSwitchToMarkdownAppliesStyling() {
         textView.string = "# Heading"
         MarkdownProcessor.applyMarkdownStyling(to: textView, using: font)

--- a/JotTests/PerformanceTests.swift
+++ b/JotTests/PerformanceTests.swift
@@ -130,14 +130,16 @@ final class PerformanceTests: XCTestCase {
     // Typing in markdown mode styles only the current line, but the pass
     // still does full-document work (background strip, code-fence scans).
     // This is the number #123 exists to shrink: it should track the line
-    // length, not the document length.
+    // length, not the document length. A mid-document line, so the range
+    // holds real markdown content — the fixture's last line is blank,
+    // which would understate the per-line cost.
     func testMarkdownCurrentLinePassOn1MBDocument() {
         let text = Self.markdownFixture(Self.oneMB)
         let textView = makeTextView(text: text)
-        let lastLineRange = (text as NSString).lineRange(
-            for: NSRange(location: (text as NSString).length - 1, length: 0))
+        let midLineRange = (text as NSString).lineRange(
+            for: NSRange(location: (text as NSString).length / 2, length: 0))
         measure(metrics: [XCTClockMetric(), XCTMemoryMetric()]) {
-            MarkdownProcessor.applyMarkdownStyling(to: textView, using: fixedFont, range: lastLineRange)
+            MarkdownProcessor.applyMarkdownStyling(to: textView, using: fixedFont, range: midLineRange)
         }
     }
 

--- a/JotTests/PerformanceTests.swift
+++ b/JotTests/PerformanceTests.swift
@@ -1,0 +1,157 @@
+//
+//  PerformanceTests.swift
+//  JotTests
+//
+//  Measurement harness for the hot paths (#142): text statistics and
+//  markdown styling over generated fixtures at three sizes.
+//
+//  These tests record metrics; they only fail against a baseline, and
+//  baselines are per-machine (set them in Xcode's Report navigator after a
+//  run — see docs/PERFORMANCE.md). In CI they just record, never fail.
+//
+
+import XCTest
+@testable import Jot
+
+@MainActor
+final class PerformanceTests: XCTestCase {
+
+    // MARK: - Fixtures (deterministic, generated per test)
+
+    static let tenKB = 10 * 1024
+    static let hundredKB = 100 * 1024
+    static let oneMB = 1024 * 1024
+
+    /// Plain prose: repeated lorem paragraphs up to roughly `bytes`.
+    static func plainFixture(_ bytes: Int) -> String {
+        let paragraph = """
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do \
+        eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim \
+        ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut \
+        aliquip ex ea commodo consequat.
+
+
+        """
+        return String(repeating: paragraph, count: max(1, bytes / paragraph.utf8.count))
+    }
+
+    /// Markdown with realistic syntax density: headings, emphasis, lists,
+    /// links, a table, a code fence, and a blockquote in every block.
+    static func markdownFixture(_ bytes: Int) -> String {
+        let block = """
+        ## Section heading
+
+        Lorem **ipsum** dolor *sit amet*, consectetur ***adipiscing*** elit.
+        Sed do `eiusmod tempor` incididunt ut [labore](https://example.com)
+        et dolore ~~magna~~ aliqua.
+
+        - Ut enim ad minim veniam
+        - Quis nostrud *exercitation* ullamco
+        - Laboris nisi ut **aliquip**
+
+        | Column | Value |
+        |--------|-------|
+        | lorem  | ipsum |
+        | dolor  | sit   |
+
+        ```swift
+        let amet = "consectetur"
+        ```
+
+        > Duis aute irure dolor in reprehenderit in voluptate velit.
+
+
+        """
+        return String(repeating: block, count: max(1, bytes / block.utf8.count))
+    }
+
+    /// An offscreen text view with a full text system, loaded with `text`.
+    private func makeTextView(text: String) -> NSTextView {
+        let textView = NSTextView(frame: NSRect(x: 0, y: 0, width: 800, height: 600))
+        textView.string = text
+        return textView
+    }
+
+    private let fixedFont = NSFont.systemFont(ofSize: 13)
+
+    // MARK: - TextStatistics (#138)
+
+    func testStatistics10KB() {
+        let text = Self.plainFixture(Self.tenKB)
+        measure(metrics: [XCTClockMetric(), XCTMemoryMetric()]) {
+            _ = TextStatistics(text: text)
+        }
+    }
+
+    func testStatistics100KB() {
+        let text = Self.plainFixture(Self.hundredKB)
+        measure(metrics: [XCTClockMetric(), XCTMemoryMetric()]) {
+            _ = TextStatistics(text: text)
+        }
+    }
+
+    func testStatistics1MB() {
+        let text = Self.plainFixture(Self.oneMB)
+        measure(metrics: [XCTClockMetric(), XCTMemoryMetric()]) {
+            _ = TextStatistics(text: text)
+        }
+    }
+
+    // MARK: - Full markdown styling pass (#141, #139)
+
+    // No 1 MB full-pass test: markdown mode's usable envelope is a few
+    // hundred KB today, and five measured iterations of a 1 MB pass would
+    // dominate the suite's runtime for no extra signal.
+
+    func testMarkdownFullPass10KB() {
+        let textView = makeTextView(text: Self.markdownFixture(Self.tenKB))
+        measure(metrics: [XCTClockMetric(), XCTMemoryMetric()]) {
+            MarkdownProcessor.applyMarkdownStyling(to: textView, using: fixedFont)
+        }
+    }
+
+    func testMarkdownFullPass100KB() {
+        let textView = makeTextView(text: Self.markdownFixture(Self.hundredKB))
+        measure(metrics: [XCTClockMetric(), XCTMemoryMetric()]) {
+            MarkdownProcessor.applyMarkdownStyling(to: textView, using: fixedFont)
+        }
+    }
+
+    // MARK: - Per-keystroke pass (#123)
+
+    // Typing in markdown mode styles only the current line, but the pass
+    // still does full-document work (background strip, code-fence scans).
+    // This is the number #123 exists to shrink: it should track the line
+    // length, not the document length.
+    func testMarkdownCurrentLinePassOn1MBDocument() {
+        let text = Self.markdownFixture(Self.oneMB)
+        let textView = makeTextView(text: text)
+        let lastLineRange = (text as NSString).lineRange(
+            for: NSRange(location: (text as NSString).length - 1, length: 0))
+        measure(metrics: [XCTClockMetric(), XCTMemoryMetric()]) {
+            MarkdownProcessor.applyMarkdownStyling(to: textView, using: fixedFont, range: lastLineRange)
+        }
+    }
+
+    // MARK: - Fixture sanity
+
+    // If a fixture generator drifts (size collapses, syntax stripped), the
+    // measurements silently stop meaning anything. Pin the basics.
+    func testFixturesAreRoughlyTheRequestedSize() {
+        for size in [Self.tenKB, Self.hundredKB, Self.oneMB] {
+            let plain = Self.plainFixture(size).utf8.count
+            let markdown = Self.markdownFixture(size).utf8.count
+            XCTAssertGreaterThan(plain, size / 2)
+            XCTAssertLessThan(plain, size * 2)
+            XCTAssertGreaterThan(markdown, size / 2)
+            XCTAssertLessThan(markdown, size * 2)
+        }
+    }
+
+    func testMarkdownFixtureExercisesTheStyler() {
+        let fixture = Self.markdownFixture(Self.tenKB)
+        for token in ["## ", "**", "`", "](", "|---", "```", "> ", "- ", "~~"] {
+            XCTAssertTrue(fixture.contains(token), "fixture lost its \(token) syntax")
+        }
+    }
+}

--- a/JotTests/PerformanceTests.swift
+++ b/JotTests/PerformanceTests.swift
@@ -97,6 +97,14 @@ final class PerformanceTests: XCTestCase {
         }
     }
 
+    // The word-count label path: one number, not seven statistics
+    func testWordCountOnly1MB() {
+        let text = Self.plainFixture(Self.oneMB)
+        measure(metrics: [XCTClockMetric(), XCTMemoryMetric()]) {
+            _ = TextStatistics.wordCount(of: text)
+        }
+    }
+
     // MARK: - Full markdown styling pass (#141, #139)
 
     // No 1 MB full-pass test: markdown mode's usable envelope is a few

--- a/JotTests/TextStatisticsTests.swift
+++ b/JotTests/TextStatisticsTests.swift
@@ -42,6 +42,17 @@ final class TextStatisticsTests: XCTestCase {
         XCTAssertEqual(stats.wordCount, 3)
     }
 
+    func testStaticWordCountMatchesFullStatistics() {
+        // The editor label uses the cheap static path; the panel builds the
+        // full statistics. They must never disagree (#138).
+        for text in ["", "one", "  one   two  ", "hello, world! -- yes",
+                     "line\nbreaks\nand\ttabs", String(repeating: "word ", count: 500)] {
+            XCTAssertEqual(TextStatistics.wordCount(of: text),
+                           TextStatistics(text: text).wordCount,
+                           "static and full word counts diverged for: \(text.prefix(30))")
+        }
+    }
+
     func testWordCountPunctuationTokens() {
         let stats = TextStatistics(text: "hello, world! -- yes")
         XCTAssertEqual(stats.wordCount, 4)

--- a/JotTests/TextStatisticsTests.swift
+++ b/JotTests/TextStatisticsTests.swift
@@ -42,6 +42,25 @@ final class TextStatisticsTests: XCTestCase {
         XCTAssertEqual(stats.wordCount, 3)
     }
 
+    func testZeroWidthSpaceSeparatesWordsButCountsAsCharacter() {
+        // CharacterSet.whitespacesAndNewlines contains U+200B (a documented
+        // quirk); Unicode's White_Space property does not. 1.0.9 split words
+        // on it while counting it as a non-space character — both preserved.
+        let stats = TextStatistics(text: "one\u{200B}two")
+        XCTAssertEqual(stats.wordCount, 2)
+        XCTAssertEqual(TextStatistics.wordCount(of: "one\u{200B}two"), 2)
+        XCTAssertEqual(stats.characterCountNoSpaces, 7)
+    }
+
+    func testCombiningMarkAfterWhitespaceKeepsOriginalSegmentation() {
+        // Deliberate correction (2026-08 review): the old filter-based count
+        // re-segmented the filtered text, so removing the newline merged the
+        // combining accent onto "a" and counted 2. Counting the original
+        // text's non-whitespace characters gives 3, which is what the stat
+        // claims to mean.
+        XCTAssertEqual(TextStatistics(text: "a\n\u{0301}b").characterCountNoSpaces, 3)
+    }
+
     func testStaticWordCountMatchesFullStatistics() {
         // The editor label uses the cheap static path; the panel builds the
         // full statistics. They must never disagree (#138).

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -1,0 +1,78 @@
+# Performance
+
+Jot's identity is "fast and light." This document is the measurement story
+behind that claim: what gets measured, how to run the measurements, and what
+the numbers looked like when the harness was built (#142).
+
+## Performance tests
+
+`JotTests/PerformanceTests.swift` measures the two hot paths — `TextStatistics`
+construction and `MarkdownProcessor.applyMarkdownStyling` — over deterministic
+generated fixtures at 10 KB, 100 KB, and 1 MB.
+
+Run them like any other test (`Cmd-U`, or `xcodebuild test`). The measured
+tests record wall-clock and memory metrics; they only *fail* against a
+baseline, and baselines are stored per-machine.
+
+**Setting baselines (do this on your Mac, not in CI):** run the tests in
+Xcode, open the Report navigator, click a performance test, and use
+"Set Baseline" on the metric you want to defend. Xcode then fails the test
+locally if a future run regresses past the baseline's tolerance. CI has no
+baselines, so CI runs just record numbers and never fail on timing — that is
+deliberate; shared runners are too noisy for hard perf assertions.
+
+The pathological-input timing tests (catastrophic-backtracking guards from
+\#122) live in `MarkdownProcessorTests.swift` and *do* hard-fail everywhere,
+because they defend against hangs, not slowness.
+
+## Signposts
+
+The app marks its hot paths with `os_signpost` intervals (subsystem
+`com.brian.jot`, category Points of Interest — see `PerformanceLog.swift`):
+
+| Signpost name         | Marks                                                  |
+|-----------------------|--------------------------------------------------------|
+| Markdown Styling      | One styling pass; message notes styled vs total chars  |
+| Word Count            | `TextStatistics` build for the editor label            |
+| Document Sync         | Debounced `textView.string` → `document.text` copy     |
+| Preview Render        | Markdown → HTML conversion + WKWebView load            |
+| Legacy Draft Restore  | One-time migration of pre-1.0.9 unsaved-state files    |
+
+In Instruments, add the **Points of Interest** instrument (it is included in
+the Time Profiler template) and the intervals appear by name. On the command
+line: `log stream --predicate 'subsystem == "com.brian.jot"' --signpost`.
+
+## Instruments playbook (~20 minutes)
+
+1. **Launch**: Instruments > App Launch template; cold-launch 3 times and
+   record time-to-first-window.
+2. **WKWebView cost**: in Activity Monitor, note memory for Jot plus the
+   "Jot Web Content" helper; open Help, close it, compare. Repeat for
+   Markdown Preview.
+3. **Typing**: Time Profiler + Allocations; paste a 1 MB file and type
+   continuously for 30 s in plain-text mode (word count on), then markdown
+   mode. The Word Count and Markdown Styling signposts should bound the work;
+   look for either dominating the trace.
+4. **Idle**: leave a document open 5 minutes under Time Profiler — the trace
+   should be flat. There are no repeating timers by design; verify it stays
+   true.
+
+## Recorded audit results (2026-08, develop @ 096dbda, pre-Phase-3)
+
+Structural typing-smoothness envelope before the Phase 3 fixes:
+
+- Plain text, word count off: ~5–10 MB documents
+- Plain text, word count on: ~1 MB (#138)
+- Markdown mode: a few hundred KB (#123, #141)
+
+Deliberate do-nothings (checked during the audit; leave alone):
+
+- `Document.text` duplicate model copy — correct model-layer design
+- About/Settings/Word Count panels retained forever — KB-scale, fine
+- No caching of stats or rendered preview HTML — debounce bounds frequency;
+  caches would be over-engineering
+- Regexes are already `static let`; release build uses `-O`, whole-module
+
+Baseline numbers from the harness on the development machine (M-series, Debug
+configuration) are recorded in the Phase 3 PR (#142 → the perf PR) for
+before/after comparison.


### PR DESCRIPTION
## Summary

Phase 3 of the 1.0.10 milestone: builds the performance measurement story (#142), then fixes the four audited hot paths (#123, #141, #139, #138) with before/after numbers from the new harness. Closes #142, #123, #141, #139, #138.

## Measured results (1 MB fixture, Debug, M-series)

| Path | Before | After |
|---|---|---|
| Markdown per-keystroke pass | 28 ms | 5 ms |
| Word-count label per typing pause | 152 ms | 22 ms |
| Full statistics (panel path) | 152 ms | 58 ms |
| Scroll pause over already-styled text | full visible restyle | skipped |

Release-mode standalone benchmarks are better still (scalar word tally ~2 ms/MB). Cold-launch idle memory A/B: branch ≤ develop (~54 vs ~56 MB RSS).

## What's in here

- **#142 harness**: `PerformanceTests.swift` (deterministic 10 KB/100 KB/1 MB fixtures, clock+memory metrics — baseline-only failures, so CI records but never fails on timing), `os_signpost` intervals on five hot paths, and `docs/PERFORMANCE.md` with the Instruments playbook and baseline workflow. Deliberately skipped: `XCTApplicationLaunchMetric` needs a UI-test target the project doesn't have — separate decision.
- **#123**: styling ranges expand to line boundaries; resets and inline-code scans bounded to the range; fence attributes applied only to intersecting blocks. Known limit (documented in code): deleting a fence leaves stale background outside the range until a wider pass covers it. The fence *scan* remains full-document — that's #164.
- **#141**: one string snapshot per styling pass. Honest result: **no measurable wall-clock change** — the predicted per-access bridge-copy cost wasn't real. Kept for shape.
- **#139**: `styledCharacters` IndexSet; scroll passes skip when the visible range is already covered. Reset on edit, revert, mode switch, and font change. All `textView.string` assignments funneled through `loadText(_:)` so the reset can't be bypassed.
- **#138**: single-pass TextStatistics via unicode-scalar tallies. Rejected the issue's `.byWords` suggestion (changes user-visible counts) and `Character` iteration (measured ~70 ms/MB even in Release). All 34 pre-existing behavior tests pass unchanged.

## Review

Two review agents (code quality/perf, accessibility) ran before this PR; a 600k-input fuzz plus a full-Unicode CharacterSet sweep verified the TextStatistics rewrite. Findings fixed in the final commit: U+200B word-separator quirk preserved from 1.0.9 (pinned by test), combining-mark `characterCountNoSpaces` correction documented and pinned, `loadText(_:)` funnel, local `ByteCountFormatter`. Spawned issues: #163 (pre-existing table-header ranged-pass quirk), #164 (fence-position caching). No VoiceOver regressions; both announcements and all seven panel stats verified.

## Test plan

- Full suite green locally after every commit (78 tests incl. 8 perf measurements)
- Hands-on testing: markdown typing/scrolling feel on large documents, fence editing, word-count toggle, font changes, revert — done by Brian
- CI: Build and Test + CodeQL (swift, actions) on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Ak643B4p59MBpJyiEDsig