### PR TITLE
feat: 1.0.10 Phase 4 — list continuation, checklists, paste-URL-as-link

### DIFF
--- a/Jot/Editor/EditorTextView.swift
+++ b/Jot/Editor/EditorTextView.swift
@@ -100,6 +100,16 @@ class EditorTextView: NSTextView {
         if selection.rangeOfCharacter(from: .newlines) != nil {
             return nil
         }
+        // Unbalanced brackets in the selection corrupt the link too:
+        // "a] b" would become "[a] b](url)" and end the link text at "a".
+        // Balanced pairs are fine — CommonMark allows them in link text.
+        var bracketDepth = 0
+        for character in selection {
+            if character == "[" { bracketDepth += 1 }
+            if character == "]" { bracketDepth -= 1 }
+            if bracketDepth < 0 { return nil }
+        }
+        if bracketDepth != 0 { return nil }
         return "[\(selection)](\(candidate))"
     }
 

--- a/Jot/Editor/EditorTextView.swift
+++ b/Jot/Editor/EditorTextView.swift
@@ -50,6 +50,59 @@ class EditorTextView: NSTextView {
         return true
     }
 
+    // MARK: - Paste URL as link (#145)
+
+    override func paste(_ sender: Any?) {
+        if pasteURLOverSelectionAsMarkdownLink() { return }
+        super.paste(sender)
+    }
+
+    /// With text selected in markdown mode, pasting a URL wraps the
+    /// selection as a markdown link instead of replacing it. Every other
+    /// case falls through to a normal paste, and Paste and Match Style is
+    /// untouched, so plain replacement stays one shortcut away.
+    private func pasteURLOverSelectionAsMarkdownLink() -> Bool {
+        guard (delegate as? EditorViewController)?.currentMode == .markdown else { return false }
+        let selectedRange = self.selectedRange()
+        guard selectedRange.length > 0 else { return false }
+        guard let pasted = NSPasteboard.general.string(forType: .string) else { return false }
+
+        let selectedText = (string as NSString).substring(with: selectedRange)
+        guard let replacement = EditorTextView.markdownLink(wrapping: selectedText, around: pasted) else {
+            return false
+        }
+        insertText(replacement, replacementRange: selectedRange)
+        return true
+    }
+
+    /// `"[selection](url)"` when `pasted` is a lone http(s) URL and the
+    /// selection can serve as link text; nil means "do a normal paste".
+    /// Static and pure so the decision is directly testable.
+    static func markdownLink(wrapping selection: String, around pasted: String) -> String? {
+        // A copied URL often arrives with a trailing newline; anything with
+        // interior whitespace is prose, not a URL.
+        let candidate = pasted.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !candidate.isEmpty,
+              candidate.rangeOfCharacter(from: .whitespacesAndNewlines) == nil,
+              let url = URL(string: candidate),
+              let scheme = url.scheme?.lowercased(),
+              scheme == "http" || scheme == "https",
+              url.host != nil else {
+            return nil
+        }
+
+        // A selection that is already a markdown link gets replaced like a
+        // normal paste instead of double-wrapped.
+        if selection.hasPrefix("["), selection.hasSuffix(")"), selection.contains("](") {
+            return nil
+        }
+        // Link text can't span lines; wrapping would produce broken syntax.
+        if selection.rangeOfCharacter(from: .newlines) != nil {
+            return nil
+        }
+        return "[\(selection)](\(candidate))"
+    }
+
     // MARK: - Helpers
 
     private func extractFileURLs(from pasteboard: NSPasteboard) -> [URL]? {

--- a/Jot/Editor/EditorViewController.swift
+++ b/Jot/Editor/EditorViewController.swift
@@ -286,41 +286,142 @@ class EditorViewController: NSViewController, NSTextViewDelegate, TextSettingsDe
 
 	// MARK: - Checklist Toggle (#146)
 
-	/// Format > Toggle Checklist: flips `[ ]`/`[x]` on every checklist line
-	/// the selection touches. Lines without a checkbox are left alone. Like
-	/// the bold/italic commands, this works in both modes — it edits
-	/// characters; only the styling is markdown-mode dependent.
-	@IBAction func toggleChecklistItem(_ sender: Any) {
-		let flips = checklistStateFlips()
-		guard !flips.isEmpty else { return }
+	/// What Format > Toggle Checklist would do to the selected lines.
+	private enum ChecklistEdit {
+		/// Flip these checkbox state characters (1-for-1 replacements).
+		case flips([(NSRange, String)])
+		/// Insert these checkbox markers at these locations.
+		case insertions([(location: Int, marker: String)])
+		case none
+	}
 
-		let savedSelection = textView.selectedRange()
-		for (stateRange, replacement) in flips {
-			textView.insertText(replacement, replacementRange: stateRange)
+	/// Format > Toggle Checklist: flips `[ ]`/`[x]` on every checklist line
+	/// the selection touches; when the selection has no checkboxes at all,
+	/// adds them instead (plain lines get "- [ ] ", bullet items get a
+	/// checkbox after the bullet). Numbered lines are left alone — Jot's
+	/// checklist syntax is bullet-based. Like the bold/italic commands this
+	/// works in both modes: it edits characters, and only the styling is
+	/// markdown-mode dependent.
+	@IBAction func toggleChecklistItem(_ sender: Any) {
+		switch checklistEdit() {
+		case .none:
+			return
+
+		case .flips(let flips):
+			let savedSelection = textView.selectedRange()
+			for (stateRange, replacement) in flips {
+				textView.insertText(replacement, replacementRange: stateRange)
+			}
+			// Every replacement is one character for one character, so the
+			// original selection is still valid.
+			textView.setSelectedRange(savedSelection)
+
+			// The flipped characters are away from the caret, so VoiceOver
+			// has nothing useful to say on its own (#146 review)
+			let checked = flips.filter { $0.1 == "x" }.count
+			let unchecked = flips.count - checked
+			if unchecked == 0 {
+				announceForAccessibility(checked == 1 ? "Checked 1 item" : "Checked \(checked) items")
+			} else if checked == 0 {
+				announceForAccessibility(unchecked == 1 ? "Unchecked 1 item" : "Unchecked \(unchecked) items")
+			} else {
+				announceForAccessibility("Toggled \(flips.count) items")
+			}
+
+		case .insertions(let insertions):
+			let original = textView.selectedRange()
+			// Back to front, so each insertion leaves the earlier
+			// locations valid.
+			for insertion in insertions.reversed() {
+				textView.insertText(insertion.marker,
+									replacementRange: NSRange(location: insertion.location, length: 0))
+			}
+			// Grow the selection over the inserted markers so it still
+			// covers the same lines. Every comparison is against the
+			// original selection — insertion locations were computed
+			// against the pre-edit text.
+			var location = original.location
+			var length = original.length
+			for insertion in insertions {
+				let markerLength = (insertion.marker as NSString).length
+				if insertion.location <= original.location {
+					location += markerLength
+				} else if insertion.location <= NSMaxRange(original) {
+					length += markerLength
+				}
+			}
+			textView.setSelectedRange(NSRange(location: location, length: length))
+
+			let count = insertions.count
+			announceForAccessibility(count == 1 ? "Added 1 checklist item" : "Added \(count) checklist items")
 		}
-		// Every replacement is one character for one character, so the
-		// original selection is still valid.
-		textView.setSelectedRange(savedSelection)
+
 		restyleSelectionLineIfMarkdown()
 	}
 
-	/// The (range, replacement) pairs that flip the checkbox state character
-	/// on each checklist line the selection touches. Computed from one text
-	/// snapshot; all replacements are same-length, so applying them in order
-	/// leaves the remaining ranges valid.
-	private func checklistStateFlips() -> [(NSRange, String)] {
+	/// The edits Toggle Checklist would make right now, from one text
+	/// snapshot. If any selected line already has a checkbox the command
+	/// flips (only) those; otherwise it inserts new checkboxes.
+	private func checklistEdit() -> ChecklistEdit {
 		let nsString = textView.string as NSString
 		let lineSpan = nsString.lineRange(for: textView.selectedRange())
+
 		var flips: [(NSRange, String)] = []
+		var insertions: [(location: Int, marker: String)] = []
+
 		nsString.enumerateSubstrings(in: lineSpan, options: .byLines) { line, lineRange, _, _ in
-			guard let line = line,
-				  let marker = ListMarker(line: line),
-				  let stateOffset = marker.checkboxStateOffset else { return }
-			let stateRange = NSRange(location: lineRange.location + stateOffset, length: 1)
-			let flipped = nsString.substring(with: stateRange) == " " ? "x" : " "
-			flips.append((stateRange, flipped))
+			guard let line = line else { return }
+			if let marker = ListMarker(line: line) {
+				if let stateOffset = marker.checkboxStateOffset {
+					let stateRange = NSRange(location: lineRange.location + stateOffset, length: 1)
+					let flipped = nsString.substring(with: stateRange) == " " ? "x" : " "
+					flips.append((stateRange, flipped))
+				} else if marker.number == nil {
+					// Plain bullet: add a checkbox after the bullet marker
+					insertions.append((lineRange.location + marker.prefixLength, "[ ] "))
+				}
+				// Numbered items get nothing: "1. [ ]" is not a checklist
+				// Jot styles or continues.
+			} else {
+				// Plain line: prefix a checkbox after any leading
+				// whitespace, so indented notes keep their nesting
+				let indentLength = line.prefix(while: { $0 == " " || $0 == "\t" }).utf16.count
+				insertions.append((lineRange.location + indentLength, "- [ ] "))
+			}
 		}
-		return flips
+
+		// A zero-length line span is the empty document or the empty last
+		// line — enumerateSubstrings yields nothing there, but the command
+		// can still start a checklist.
+		if flips.isEmpty && insertions.isEmpty && lineSpan.length == 0 {
+			insertions.append((lineSpan.location, "- [ ] "))
+		}
+
+		if !flips.isEmpty { return .flips(flips) }
+		if !insertions.isEmpty { return .insertions(insertions) }
+		return .none
+	}
+
+	/// Early-exit existence check so validating the Format menu doesn't
+	/// scan an entire Select All selection line by line. Must stay in
+	/// agreement with checklistEdit(): work exists unless every selected
+	/// line is a numbered list item.
+	private func selectionHasChecklistWork() -> Bool {
+		let nsString = textView.string as NSString
+		let lineSpan = nsString.lineRange(for: textView.selectedRange())
+		if lineSpan.length == 0 { return true }
+
+		var found = false
+		nsString.enumerateSubstrings(in: lineSpan, options: .byLines) { line, _, _, stop in
+			guard let line = line else { return }
+			if let marker = ListMarker(line: line) {
+				found = marker.isCheckbox || marker.number == nil
+			} else {
+				found = true
+			}
+			if found { stop.pointee = true }
+		}
+		return found
 	}
 
 	// MARK: - Word Count and Other Actions
@@ -426,6 +527,17 @@ class EditorViewController: NSViewController, NSTextViewDelegate, TextSettingsDe
 		modePopUpButton.setAccessibilityLabel("Editor mode")
 		textView.setAccessibilityLabel("Document editor")
 	}
+
+	/// Spoken feedback for commands whose visible effect is away from the
+	/// caret (checklist toggles, the list escape hatch). Same pattern as
+	/// the mode-switch and revert announcements.
+	private func announceForAccessibility(_ message: String) {
+		NSAccessibility.post(
+			element: textView as Any,
+			notification: .announcementRequested,
+			userInfo: [.announcement: message]
+		)
+	}
 }
 
 // MARK: - NSTextViewDelegate
@@ -463,6 +575,9 @@ extension EditorViewController {
 			return true
 		case .endList(let removeRange):
 			textView.insertText("", replacementRange: removeRange)
+			// The one Return that deletes instead of inserting — say so,
+			// or a VoiceOver user hears "Return is broken" (#143 review)
+			announceForAccessibility("List ended")
 			return true
 		case .none:
 			return false
@@ -572,8 +687,9 @@ extension EditorViewController {
 extension EditorViewController: NSMenuItemValidation {
 	func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {
 		if menuItem.action == #selector(toggleChecklistItem(_:)) {
-			// Only meaningful when the selection touches a checklist line
-			return !checklistStateFlips().isEmpty
+			// Disabled only when there is nothing to flip or add — in
+			// practice, when the selection is entirely numbered-list items
+			return selectionHasChecklistWork()
 		}
 		// Every other action this controller exposes stays enabled, which
 		// is what AppKit did before this method existed.

--- a/Jot/Editor/EditorViewController.swift
+++ b/Jot/Editor/EditorViewController.swift
@@ -400,7 +400,34 @@ extension EditorViewController {
 			handleBacktab()
 			return true
 		}
+		if selector == #selector(insertNewline(_:)) {
+			return continueListOnReturn()
+		}
 		return false
+	}
+
+	// MARK: - List continuation (#143)
+
+	/// Pressing Return inside a markdown list item starts the next line with
+	/// the same marker (ordered numbers increment, checkboxes reset to
+	/// unchecked); Return on an empty item deletes its marker instead — the
+	/// standard way out of a list. Markdown mode only: plain-text mode stays
+	/// plain. Returns false to let the text view insert a normal newline.
+	private func continueListOnReturn() -> Bool {
+		guard currentMode == .markdown else { return false }
+		let selectedRange = textView.selectedRange()
+		guard selectedRange.length == 0 else { return false }
+
+		switch ListMarker.returnAction(in: textView.string, caret: selectedRange.location) {
+		case .continueList(let insert):
+			textView.insertText(insert, replacementRange: selectedRange)
+			return true
+		case .endList(let removeRange):
+			textView.insertText("", replacementRange: removeRange)
+			return true
+		case .none:
+			return false
+		}
 	}
 
 	// MARK: - Tab / Indent

--- a/Jot/Editor/EditorViewController.swift
+++ b/Jot/Editor/EditorViewController.swift
@@ -284,6 +284,45 @@ class EditorViewController: NSViewController, NSTextViewDelegate, TextSettingsDe
 		applyStyling(range: lineRange)
 	}
 
+	// MARK: - Checklist Toggle (#146)
+
+	/// Format > Toggle Checklist: flips `[ ]`/`[x]` on every checklist line
+	/// the selection touches. Lines without a checkbox are left alone. Like
+	/// the bold/italic commands, this works in both modes — it edits
+	/// characters; only the styling is markdown-mode dependent.
+	@IBAction func toggleChecklistItem(_ sender: Any) {
+		let flips = checklistStateFlips()
+		guard !flips.isEmpty else { return }
+
+		let savedSelection = textView.selectedRange()
+		for (stateRange, replacement) in flips {
+			textView.insertText(replacement, replacementRange: stateRange)
+		}
+		// Every replacement is one character for one character, so the
+		// original selection is still valid.
+		textView.setSelectedRange(savedSelection)
+		restyleSelectionLineIfMarkdown()
+	}
+
+	/// The (range, replacement) pairs that flip the checkbox state character
+	/// on each checklist line the selection touches. Computed from one text
+	/// snapshot; all replacements are same-length, so applying them in order
+	/// leaves the remaining ranges valid.
+	private func checklistStateFlips() -> [(NSRange, String)] {
+		let nsString = textView.string as NSString
+		let lineSpan = nsString.lineRange(for: textView.selectedRange())
+		var flips: [(NSRange, String)] = []
+		nsString.enumerateSubstrings(in: lineSpan, options: .byLines) { line, lineRange, _, _ in
+			guard let line = line,
+				  let marker = ListMarker(line: line),
+				  let stateOffset = marker.checkboxStateOffset else { return }
+			let stateRange = NSRange(location: lineRange.location + stateOffset, length: 1)
+			let flipped = nsString.substring(with: stateRange) == " " ? "x" : " "
+			flips.append((stateRange, flipped))
+		}
+		return flips
+	}
+
 	// MARK: - Word Count and Other Actions
 	@IBAction func toggleWordCountDisplay(_ sender: NSButton) {
 		if sender.state == .on {
@@ -526,5 +565,18 @@ extension EditorViewController {
 		}
 
 		NotificationCenter.default.post(name: WordCountPanelController.textDidChangeNotification, object: self)
+	}
+}
+
+// MARK: - Menu validation
+extension EditorViewController: NSMenuItemValidation {
+	func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {
+		if menuItem.action == #selector(toggleChecklistItem(_:)) {
+			// Only meaningful when the selection touches a checklist line
+			return !checklistStateFlips().isEmpty
+		}
+		// Every other action this controller exposes stays enabled, which
+		// is what AppKit did before this method existed.
+		return true
 	}
 }

--- a/Jot/Markdown/ListMarker.swift
+++ b/Jot/Markdown/ListMarker.swift
@@ -1,0 +1,125 @@
+//
+//  ListMarker.swift
+//  Jot
+//
+//  Parses the list marker at the start of a markdown line. Shared by the
+//  Return-key list continuation (#143) and the checklist commands (#146).
+//
+
+import Foundation
+
+/// The leading marker of a markdown list line: indentation plus a bullet
+/// (`- `, `* `, `+ `), an ordered number (`3. `), or a checkbox bullet
+/// (`- [ ] `, `- [x] `).
+struct ListMarker {
+
+	/// Leading whitespace before the marker (tabs/spaces), preserved so
+	/// continued items keep their nesting depth.
+	let indent: String
+
+	/// The marker text after the indent, through the space that separates
+	/// it from the content: `"- "`, `"3. "`, or `"- [x] "`.
+	let text: String
+
+	/// The number of an ordered-list marker (`"3. "` → 3); nil for bullets.
+	let number: Int?
+
+	/// UTF-16 offset from the start of the line of the checkbox state
+	/// character (the one between the brackets); nil when the marker has
+	/// no checkbox.
+	let checkboxStateOffset: Int?
+
+	var isCheckbox: Bool { return checkboxStateOffset != nil }
+
+	/// Length of indent + marker in UTF-16 units, for cursor math against
+	/// NSString-based ranges.
+	var prefixLength: Int {
+		return (indent as NSString).length + (text as NSString).length
+	}
+
+	// Group 1: indent. Group 2: bullet character. Group 3: checkbox, if
+	// present. Group 4: ordered-list number (capped at 9 digits so Int
+	// conversion can't overflow). A space after the marker is required —
+	// a bare "-" or "1." is ordinary text, and the trailing space keeps
+	// this in step with MarkdownProcessor's list regexes.
+	private static let regex = try! NSRegularExpression(
+		pattern: "^([ \\t]*)(?:([-+*])( \\[[ xX]\\])? |(\\d{1,9})\\. )")
+
+	/// Parses the marker at the start of `line` (a single line, without its
+	/// trailing newline). Fails when the line is not a list item.
+	init?(line: String) {
+		let nsLine = line as NSString
+		let fullRange = NSRange(location: 0, length: nsLine.length)
+		guard let match = Self.regex.firstMatch(in: line, options: [], range: fullRange) else {
+			return nil
+		}
+
+		let indentRange = match.range(at: 1)
+		indent = nsLine.substring(with: indentRange)
+		text = nsLine.substring(with: NSRange(location: indentRange.length,
+											  length: match.range.length - indentRange.length))
+
+		let numberRange = match.range(at: 4)
+		number = numberRange.location == NSNotFound
+			? nil
+			: Int(nsLine.substring(with: numberRange))
+
+		let checkboxRange = match.range(at: 3)
+		// The checkbox group is " [x]"; the state character sits after
+		// the space and the opening bracket.
+		checkboxStateOffset = checkboxRange.location == NSNotFound
+			? nil
+			: checkboxRange.location + 2
+	}
+
+	/// The prefix that starts the next item: same indent and marker, with
+	/// ordered numbers incremented and checkboxes reset to unchecked.
+	var continuationPrefix: String {
+		if let number = number {
+			return indent + "\(number + 1). "
+		}
+		if isCheckbox {
+			// First character of the marker text is the bullet.
+			return indent + String(text.prefix(1)) + " [ ] "
+		}
+		return indent + text
+	}
+
+	// MARK: - Return-key behavior (#143)
+
+	enum ReturnAction: Equatable {
+		/// Continue the list: insert this text (newline + next marker) at
+		/// the caret.
+		case continueList(insert: String)
+		/// Return on an empty item ends the list: delete this range (the
+		/// whole line content) and leave the caret on the now-plain line.
+		case endList(remove: NSRange)
+		/// Not a list context — let the text view insert a plain newline.
+		case none
+	}
+
+	/// What pressing Return at `caret` (a UTF-16 offset with no selection)
+	/// should do. Pure function of the text so it can be tested without a
+	/// text view.
+	static func returnAction(in text: String, caret: Int) -> ReturnAction {
+		let nsString = text as NSString
+		guard caret >= 0 && caret <= nsString.length else { return .none }
+
+		let lineRange = nsString.lineRange(for: NSRange(location: caret, length: 0))
+		var line = nsString.substring(with: lineRange)
+		if line.hasSuffix("\n") { line.removeLast() }
+
+		guard let marker = ListMarker(line: line) else { return .none }
+
+		// Only act when the caret sits in the content, past the marker;
+		// Return at the line start should just push the line down.
+		guard caret - lineRange.location >= marker.prefixLength else { return .none }
+
+		let content = (line as NSString).substring(from: marker.prefixLength)
+		if content.trimmingCharacters(in: .whitespaces).isEmpty {
+			return .endList(remove: NSRange(location: lineRange.location,
+											length: (line as NSString).length))
+		}
+		return .continueList(insert: "\n" + marker.continuationPrefix)
+	}
+}

--- a/Jot/Markdown/ListMarker.swift
+++ b/Jot/Markdown/ListMarker.swift
@@ -105,20 +105,30 @@ struct ListMarker {
 		let nsString = text as NSString
 		guard caret >= 0 && caret <= nsString.length else { return .none }
 
-		let lineRange = nsString.lineRange(for: NSRange(location: caret, length: 0))
-		var line = nsString.substring(with: lineRange)
-		if line.hasSuffix("\n") { line.removeLast() }
+		// getLineStart's contentsEnd excludes the line terminator. That
+		// matters for CRLF files: lineRange includes the "\r\n", and a
+		// String hasSuffix("\n") check never matches it because Swift
+		// compares whole graphemes and "\r\n" is one Character.
+		var lineStart = 0
+		var lineEnd = 0
+		var contentsEnd = 0
+		nsString.getLineStart(&lineStart, end: &lineEnd, contentsEnd: &contentsEnd,
+							  for: NSRange(location: caret, length: 0))
+		let line = nsString.substring(with: NSRange(location: lineStart,
+													length: contentsEnd - lineStart))
 
 		guard let marker = ListMarker(line: line) else { return .none }
 
 		// Only act when the caret sits in the content, past the marker;
 		// Return at the line start should just push the line down.
-		guard caret - lineRange.location >= marker.prefixLength else { return .none }
+		guard caret - lineStart >= marker.prefixLength else { return .none }
 
+		// Whitespace-only content is an empty item: Return clears the
+		// whole line, stray trailing spaces included.
 		let content = (line as NSString).substring(from: marker.prefixLength)
 		if content.trimmingCharacters(in: .whitespaces).isEmpty {
-			return .endList(remove: NSRange(location: lineRange.location,
-											length: (line as NSString).length))
+			return .endList(remove: NSRange(location: lineStart,
+											length: contentsEnd - lineStart))
 		}
 		return .continueList(insert: "\n" + marker.continuationPrefix)
 	}

--- a/Jot/Markdown/MarkdownProcessor.swift
+++ b/Jot/Markdown/MarkdownProcessor.swift
@@ -240,7 +240,10 @@ enum MarkdownProcessor {
 			textStorage.addAttribute(.foregroundColor, value: NSColor.secondaryLabelColor, range: markerRange)
 
 			// Checked items read as done: struck through and dimmed. Runs
-			// after the inline passes, so the whole item dims uniformly.
+			// after the inline passes, so the whole item — links, bold,
+			// code included — dims to one color. Deliberate (matches
+			// Reminders/Notes); the [x] characters still carry the state
+			// for assistive tech, and .link clickability is untouched.
 			let state = (string as NSString).substring(with: stateRange)
 			if state != " " && contentRange.length > 0 {
 				textStorage.addAttribute(.strikethroughStyle, value: NSUnderlineStyle.single.rawValue, range: contentRange)

--- a/Jot/Markdown/MarkdownProcessor.swift
+++ b/Jot/Markdown/MarkdownProcessor.swift
@@ -32,6 +32,10 @@ enum MarkdownProcessor {
 	private static let strikethroughRegex  = try! NSRegularExpression(pattern: "~~([^~\\n]+)~~",                    options: [])
 	private static let unorderedListRegex  = try! NSRegularExpression(pattern: "^[-+*]\\s+",                        options: [.anchorsMatchLines])
 	private static let orderedListRegex    = try! NSRegularExpression(pattern: "^\\d+\\.\\s+",                      options: [.anchorsMatchLines])
+	// Checklist (#146): group 1 marker, group 2 state character, group 3
+	// content. Adjacent character classes are disjoint at every position,
+	// so the pattern stays linear (see #122 for why that matters here).
+	private static let checklistRegex      = try! NSRegularExpression(pattern: "^([ \\t]*[-+*] \\[([ xX])\\] )(.*)$", options: [.anchorsMatchLines])
 	private static let blockquoteRegex     = try! NSRegularExpression(pattern: "^(>[ \\t]*)(.+)$",                  options: [.anchorsMatchLines])
 	private static let horizontalRuleRegex = try! NSRegularExpression(pattern: "^([-*_]{3,})[ \\t]*$",             options: [.anchorsMatchLines])
 	// Table: lines containing pipe delimiters. Separator rows (|---|---|) get distinct styling.
@@ -102,6 +106,7 @@ enum MarkdownProcessor {
 		applyLinks(to: textStorage, in: string, range: stylingRange)
 		applyStrikethrough(to: textStorage, in: string, range: stylingRange)
 		applyListStyling(to: textStorage, in: string, range: stylingRange)
+		applyChecklists(to: textStorage, in: string, range: stylingRange)
 		applyBlockquotes(to: textStorage, in: string, range: stylingRange)
 		applyHorizontalRules(to: textStorage, in: string, range: stylingRange)
 		applyTables(to: textStorage, in: string, using: selectedFont, range: stylingRange)
@@ -220,6 +225,26 @@ enum MarkdownProcessor {
 			regex.enumerateMatches(in: string, options: [], range: range) { match, _, _ in
 				guard let matchRange = match?.range else { return }
 				textStorage.addAttributes(markerAttributes, range: matchRange)
+			}
+		}
+	}
+
+	// MARK: - Checklists
+
+	private static func applyChecklists(to textStorage: NSTextStorage, in string: String, range: NSRange) {
+		checklistRegex.enumerateMatches(in: string, options: [], range: range) { match, _, _ in
+			guard let markerRange  = match?.range(at: 1),
+				  let stateRange   = match?.range(at: 2),
+				  let contentRange = match?.range(at: 3) else { return }
+
+			textStorage.addAttribute(.foregroundColor, value: NSColor.secondaryLabelColor, range: markerRange)
+
+			// Checked items read as done: struck through and dimmed. Runs
+			// after the inline passes, so the whole item dims uniformly.
+			let state = (string as NSString).substring(with: stateRange)
+			if state != " " && contentRange.length > 0 {
+				textStorage.addAttribute(.strikethroughStyle, value: NSUnderlineStyle.single.rawValue, range: contentRange)
+				textStorage.addAttribute(.foregroundColor, value: NSColor.secondaryLabelColor, range: contentRange)
 			}
 		}
 	}

--- a/Jot/Resources/Base.lproj/Main.storyboard
+++ b/Jot/Resources/Base.lproj/Main.storyboard
@@ -592,6 +592,12 @@
                                                 </items>
                                             </menu>
                                         </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="tgC-sp-001"/>
+                                        <menuItem title="Toggle Checklist" keyEquivalent="l" id="tgC-mi-001">
+                                            <connections>
+                                                <action selector="toggleChecklistItem:" target="Ady-hI-5gd" id="tgC-ac-001"/>
+                                            </connections>
+                                        </menuItem>
                                     </items>
                                 </menu>
                             </menuItem>
@@ -948,6 +954,4 @@
             <point key="canvasLocation" x="1326" y="1070"/>
         </scene>
     </scenes>
-    <resources>
-    </resources>
 </document>

--- a/Jot/Resources/index.html
+++ b/Jot/Resources/index.html
@@ -121,7 +121,7 @@
 		<ul>
 		<li><code>[link text](https://example.com)</code></li>
 		</ul>
-		<p>In Markdown Mode, you can also select some text and paste a copied URL over it: the selection becomes the link text. To replace the selection with the URL instead, use Edit &gt; Paste and Match Style.</p>
+		<p>In Markdown Mode, you can also select some text and paste a copied URL over it: the selection becomes the link text. To replace the selection with the URL instead, use Edit &gt; Paste and Match Style (&#8997;&#8679;&#8984;V).</p>
 		<h3>Lists</h3>
 		<p>For unordered lists, use <code>-</code>, <code>+</code>, or <code>*</code> followed by a space:</p>
 		<ul>
@@ -135,14 +135,14 @@
 		<li><code>2. Item 2</code></li>
 		<li><code>3. Item 3</code></li>
 		</ol>
-		<p>In Markdown Mode, pressing Return inside a list item starts the next item automatically (numbered lists count up as you go). Press Return on an empty item to end the list.</p>
+		<p>In Markdown Mode, pressing Return inside a list item starts the next item automatically (numbered lists count up as you go). Press Return on an empty item to end the list. Jot doesn't renumber the rest of a numbered list when you insert an item in the middle &mdash; adjust the following numbers by hand.</p>
 		<h3>Checklists</h3>
 		<p>For task lists, use a bullet followed by brackets:</p>
 		<ul>
 		<li><code>- [ ] An open task</code></li>
 		<li><code>- [x] A completed task</code></li>
 		</ul>
-		<p>Completed tasks appear crossed out in Markdown Mode. Use Format &gt; Toggle Checklist (&#8984;L) to check or uncheck the current line or every selected line.</p>
+		<p>Completed tasks appear crossed out in Markdown Mode. Use Format &gt; Toggle Checklist (&#8984;L) to check or uncheck the current line or every selected line. On lines that have no checkbox yet, the same command adds one &mdash; plain lines and bullet items become open tasks.</p>
 		<p>Feel free to experiment with these styling functions to enhance your writing experience in our app! If you have any questions or need further assistance, please don't hesitate to reach out to our support team.</p>
 	</section>
 	<section id="feedback-support">

--- a/Jot/Resources/index.html
+++ b/Jot/Resources/index.html
@@ -121,6 +121,7 @@
 		<ul>
 		<li><code>[link text](https://example.com)</code></li>
 		</ul>
+		<p>In Markdown Mode, you can also select some text and paste a copied URL over it: the selection becomes the link text. To replace the selection with the URL instead, use Edit &gt; Paste and Match Style.</p>
 		<h3>Lists</h3>
 		<p>For unordered lists, use <code>-</code>, <code>+</code>, or <code>*</code> followed by a space:</p>
 		<ul>

--- a/Jot/Resources/index.html
+++ b/Jot/Resources/index.html
@@ -135,6 +135,13 @@
 		<li><code>3. Item 3</code></li>
 		</ol>
 		<p>In Markdown Mode, pressing Return inside a list item starts the next item automatically (numbered lists count up as you go). Press Return on an empty item to end the list.</p>
+		<h3>Checklists</h3>
+		<p>For task lists, use a bullet followed by brackets:</p>
+		<ul>
+		<li><code>- [ ] An open task</code></li>
+		<li><code>- [x] A completed task</code></li>
+		</ul>
+		<p>Completed tasks appear crossed out in Markdown Mode. Use Format &gt; Toggle Checklist (&#8984;L) to check or uncheck the current line or every selected line.</p>
 		<p>Feel free to experiment with these styling functions to enhance your writing experience in our app! If you have any questions or need further assistance, please don't hesitate to reach out to our support team.</p>
 	</section>
 	<section id="feedback-support">

--- a/Jot/Resources/index.html
+++ b/Jot/Resources/index.html
@@ -134,6 +134,7 @@
 		<li><code>2. Item 2</code></li>
 		<li><code>3. Item 3</code></li>
 		</ol>
+		<p>In Markdown Mode, pressing Return inside a list item starts the next item automatically (numbered lists count up as you go). Press Return on an empty item to end the list.</p>
 		<p>Feel free to experiment with these styling functions to enhance your writing experience in our app! If you have any questions or need further assistance, please don't hesitate to reach out to our support team.</p>
 	</section>
 	<section id="feedback-support">

--- a/JotTests/ChecklistToggleTests.swift
+++ b/JotTests/ChecklistToggleTests.swift
@@ -1,0 +1,126 @@
+//
+//  ChecklistToggleTests.swift
+//  JotTests
+//
+//  End-to-end tests for Format > Toggle Checklist (#146): flipping
+//  existing checkboxes, and adding checkboxes when the selection has
+//  none. Uses the same live document/editor harness as
+//  EditorFormattingTests.
+//
+
+import XCTest
+@testable import Jot
+
+@MainActor
+final class ChecklistToggleTests: XCTestCase {
+
+	private struct ToggleResult {
+		let text: String
+		let selection: NSRange
+	}
+
+	// Each test builds its own document/editor pair: XCTest's setUp is
+	// nonisolated under Swift 6, so stored main-actor fixtures fight the
+	// compiler for no benefit
+	private func runToggle(_ text: String, select: NSRange) throws -> ToggleResult {
+		let document = Document()
+		document.makeWindowControllers()
+		defer { document.close() }
+
+		let editor = try XCTUnwrap(
+			document.windowControllers.first?.contentViewController as? EditorViewController
+		)
+		editor.textView.string = text
+		editor.textView.setSelectedRange(select)
+		editor.toggleChecklistItem(self)
+		return ToggleResult(text: editor.textView.string, selection: editor.textView.selectedRange())
+	}
+
+	// MARK: - Flipping
+
+	func testChecksSingleItem() throws {
+		XCTAssertEqual(try runToggle("- [ ] task", select: NSRange(location: 8, length: 0)).text,
+					   "- [x] task")
+	}
+
+	func testUnchecksSingleItem() throws {
+		XCTAssertEqual(try runToggle("- [x] task", select: NSRange(location: 8, length: 0)).text,
+					   "- [ ] task")
+	}
+
+	func testFlipsEverySelectedChecklistLineIndividually() throws {
+		// Mixed states flip independently; when the selection has any
+		// checkboxes, lines without one are left alone
+		let result = try runToggle("- [ ] a\n- [x] b\nplain",
+								   select: NSRange(location: 0, length: 21))
+		XCTAssertEqual(result.text, "- [x] a\n- [ ] b\nplain")
+	}
+
+	func testFlipPreservesSelection() throws {
+		let result = try runToggle("- [ ] a\n- [ ] b", select: NSRange(location: 0, length: 15))
+		XCTAssertEqual(result.selection, NSRange(location: 0, length: 15))
+	}
+
+	// MARK: - Adding
+
+	func testAddsCheckboxToPlainLine() throws {
+		let result = try runToggle("note", select: NSRange(location: 4, length: 0))
+		XCTAssertEqual(result.text, "- [ ] note")
+		// Caret shifted past the inserted marker
+		XCTAssertEqual(result.selection, NSRange(location: 10, length: 0))
+	}
+
+	func testAddsCheckboxAfterExistingBullet() throws {
+		XCTAssertEqual(try runToggle("- item", select: NSRange(location: 3, length: 0)).text,
+					   "- [ ] item")
+	}
+
+	func testKeepsIndentWhenAddingCheckbox() throws {
+		XCTAssertEqual(try runToggle("\tnote", select: NSRange(location: 2, length: 0)).text,
+					   "\t- [ ] note")
+	}
+
+	func testAddsCheckboxesToAllSelectedPlainLines() throws {
+		let result = try runToggle("one\ntwo", select: NSRange(location: 0, length: 7))
+		XCTAssertEqual(result.text, "- [ ] one\n- [ ] two")
+		// Selection still spans from the first content to the end
+		XCTAssertEqual(result.selection, NSRange(location: 6, length: 13))
+	}
+
+	func testEmptyDocumentStartsChecklist() throws {
+		let result = try runToggle("", select: NSRange(location: 0, length: 0))
+		XCTAssertEqual(result.text, "- [ ] ")
+		XCTAssertEqual(result.selection, NSRange(location: 6, length: 0))
+	}
+
+	func testEmptyLastLineStartsChecklistItem() throws {
+		let result = try runToggle("note\n", select: NSRange(location: 5, length: 0))
+		XCTAssertEqual(result.text, "note\n- [ ] ")
+	}
+
+	func testNumberedLinesAreLeftAlone() throws {
+		// "1. [ ]" is not a checklist Jot styles or continues, so the
+		// command must not manufacture one
+		let result = try runToggle("1. a\n2. b", select: NSRange(location: 0, length: 9))
+		XCTAssertEqual(result.text, "1. a\n2. b")
+	}
+
+	// MARK: - Undo
+
+	func testOneUndoRevertsMultiLineFlip() throws {
+		let document = Document()
+		document.makeWindowControllers()
+		defer { document.close() }
+
+		let editor = try XCTUnwrap(
+			document.windowControllers.first?.contentViewController as? EditorViewController
+		)
+		editor.textView.string = "- [ ] a\n- [ ] b"
+		editor.textView.setSelectedRange(NSRange(location: 0, length: 15))
+		editor.toggleChecklistItem(self)
+		XCTAssertEqual(editor.textView.string, "- [x] a\n- [x] b")
+
+		editor.textView.undoManager?.undo()
+		XCTAssertEqual(editor.textView.string, "- [ ] a\n- [ ] b")
+	}
+}

--- a/JotTests/EditorTextViewTests.swift
+++ b/JotTests/EditorTextViewTests.swift
@@ -1,0 +1,78 @@
+//
+//  EditorTextViewTests.swift
+//  JotTests
+//
+//  Tests for the paste-URL-over-selection link wrapping (#145). The
+//  decision function is pure; the paste plumbing itself is exercised by
+//  hand (it needs a live pasteboard and first responder).
+//
+
+import XCTest
+@testable import Jot
+
+@MainActor
+final class EditorTextViewTests: XCTestCase {
+
+	func testHTTPSURLWrapsSelection() {
+		XCTAssertEqual(
+			EditorTextView.markdownLink(wrapping: "the docs", around: "https://example.com/docs"),
+			"[the docs](https://example.com/docs)")
+	}
+
+	func testHTTPURLWrapsSelection() {
+		XCTAssertEqual(
+			EditorTextView.markdownLink(wrapping: "old site", around: "http://example.com"),
+			"[old site](http://example.com)")
+	}
+
+	func testCopiedURLWithTrailingNewlineIsTrimmed() {
+		XCTAssertEqual(
+			EditorTextView.markdownLink(wrapping: "docs", around: "https://example.com\n"),
+			"[docs](https://example.com)")
+	}
+
+	func testUppercaseSchemeWraps() {
+		// URLs copied from some apps arrive with an uppercased scheme
+		XCTAssertEqual(
+			EditorTextView.markdownLink(wrapping: "docs", around: "HTTPS://example.com"),
+			"[docs](HTTPS://example.com)")
+	}
+
+	func testProseDoesNotWrap() {
+		XCTAssertNil(EditorTextView.markdownLink(wrapping: "sel", around: "just some words"))
+		XCTAssertNil(EditorTextView.markdownLink(wrapping: "sel", around: "visit https://example.com today"))
+	}
+
+	func testNonHTTPSchemesDoNotWrap() {
+		XCTAssertNil(EditorTextView.markdownLink(wrapping: "sel", around: "ftp://example.com/file"))
+		XCTAssertNil(EditorTextView.markdownLink(wrapping: "sel", around: "mailto:someone@example.com"))
+		XCTAssertNil(EditorTextView.markdownLink(wrapping: "sel", around: "file:///etc/hosts"))
+	}
+
+	func testBareDomainWithoutSchemeDoesNotWrap() {
+		// Requiring a scheme keeps ordinary words like "example.com" (or
+		// "index.html") from being treated as URLs.
+		XCTAssertNil(EditorTextView.markdownLink(wrapping: "sel", around: "example.com"))
+	}
+
+	func testSchemeWithoutHostDoesNotWrap() {
+		XCTAssertNil(EditorTextView.markdownLink(wrapping: "sel", around: "https://"))
+	}
+
+	func testEmptyPasteboardStringDoesNotWrap() {
+		XCTAssertNil(EditorTextView.markdownLink(wrapping: "sel", around: ""))
+		XCTAssertNil(EditorTextView.markdownLink(wrapping: "sel", around: "  \n"))
+	}
+
+	func testExistingMarkdownLinkSelectionFallsThrough() {
+		XCTAssertNil(EditorTextView.markdownLink(
+			wrapping: "[docs](https://old.example.com)",
+			around: "https://new.example.com"))
+	}
+
+	func testMultilineSelectionFallsThrough() {
+		XCTAssertNil(EditorTextView.markdownLink(
+			wrapping: "line one\nline two",
+			around: "https://example.com"))
+	}
+}

--- a/JotTests/EditorTextViewTests.swift
+++ b/JotTests/EditorTextViewTests.swift
@@ -70,6 +70,20 @@ final class EditorTextViewTests: XCTestCase {
 			around: "https://new.example.com"))
 	}
 
+	func testUnbalancedBracketSelectionFallsThrough() {
+		// "a] b" would become "[a] b](url)" — link text ends at "a" and
+		// the rest renders as literal junk (2026-08 review)
+		XCTAssertNil(EditorTextView.markdownLink(wrapping: "a] b", around: "https://example.com"))
+		XCTAssertNil(EditorTextView.markdownLink(wrapping: "open [bracket", around: "https://example.com"))
+	}
+
+	func testBalancedBracketSelectionWraps() {
+		// CommonMark allows balanced brackets in link text
+		XCTAssertEqual(
+			EditorTextView.markdownLink(wrapping: "see [1] here", around: "https://example.com"),
+			"[see [1] here](https://example.com)")
+	}
+
 	func testMultilineSelectionFallsThrough() {
 		XCTAssertNil(EditorTextView.markdownLink(
 			wrapping: "line one\nline two",

--- a/JotTests/ListMarkerTests.swift
+++ b/JotTests/ListMarkerTests.swift
@@ -1,0 +1,158 @@
+//
+//  ListMarkerTests.swift
+//  JotTests
+//
+//  Tests for ListMarker parsing and the Return-key list continuation (#143).
+//
+
+import XCTest
+@testable import Jot
+
+final class ListMarkerTests: XCTestCase {
+
+	// MARK: - Parsing
+
+	func testParsesBulletMarkers() {
+		for bullet in ["-", "*", "+"] {
+			let marker = ListMarker(line: "\(bullet) item")
+			XCTAssertNotNil(marker, "\(bullet) should parse")
+			XCTAssertEqual(marker?.indent, "")
+			XCTAssertEqual(marker?.text, "\(bullet) ")
+			XCTAssertNil(marker?.number)
+			XCTAssertEqual(marker?.isCheckbox, false)
+		}
+	}
+
+	func testParsesOrderedMarker() {
+		let marker = ListMarker(line: "3. item")
+		XCTAssertEqual(marker?.text, "3. ")
+		XCTAssertEqual(marker?.number, 3)
+		XCTAssertEqual(marker?.isCheckbox, false)
+	}
+
+	func testParsesIndentedMarker() {
+		let marker = ListMarker(line: "\t- nested")
+		XCTAssertEqual(marker?.indent, "\t")
+		XCTAssertEqual(marker?.text, "- ")
+		XCTAssertEqual(marker?.prefixLength, 3)
+	}
+
+	func testParsesUncheckedCheckbox() {
+		let marker = ListMarker(line: "- [ ] task")
+		XCTAssertEqual(marker?.text, "- [ ] ")
+		XCTAssertEqual(marker?.isCheckbox, true)
+		XCTAssertEqual(marker?.checkboxStateOffset, 3)
+	}
+
+	func testParsesCheckedCheckbox() {
+		let marker = ListMarker(line: "  - [x] done")
+		XCTAssertEqual(marker?.indent, "  ")
+		XCTAssertEqual(marker?.text, "- [x] ")
+		XCTAssertEqual(marker?.isCheckbox, true)
+		// Offset is from the line start: 2 indent + "- [" = 5
+		XCTAssertEqual(marker?.checkboxStateOffset, 5)
+	}
+
+	func testCheckboxRequiresBullet() {
+		// "1. [ ]" is not GitHub checkbox syntax Jot recognizes; the bracket
+		// text is ordinary content.
+		let marker = ListMarker(line: "1. [ ] task")
+		XCTAssertEqual(marker?.number, 1)
+		XCTAssertEqual(marker?.isCheckbox, false)
+	}
+
+	func testNonListLinesDoNotParse() {
+		for line in ["text", "-no space", "1.no space", "", "  ", "--", "1) item"] {
+			XCTAssertNil(ListMarker(line: line), "\"\(line)\" should not parse as a list marker")
+		}
+	}
+
+	func testCheckboxWithoutTrailingSpaceFallsBackToBullet() {
+		// "- [ ]x" has no space after the brackets, so the brackets are
+		// content, not a checkbox.
+		let marker = ListMarker(line: "- [ ]x")
+		XCTAssertEqual(marker?.text, "- ")
+		XCTAssertEqual(marker?.isCheckbox, false)
+	}
+
+	// MARK: - Continuation prefixes
+
+	func testBulletContinuationKeepsMarker() {
+		XCTAssertEqual(ListMarker(line: "* item")?.continuationPrefix, "* ")
+		XCTAssertEqual(ListMarker(line: "\t- item")?.continuationPrefix, "\t- ")
+	}
+
+	func testOrderedContinuationIncrements() {
+		XCTAssertEqual(ListMarker(line: "1. item")?.continuationPrefix, "2. ")
+		XCTAssertEqual(ListMarker(line: "  9. item")?.continuationPrefix, "  10. ")
+	}
+
+	func testCheckboxContinuationResetsToUnchecked() {
+		XCTAssertEqual(ListMarker(line: "- [x] done")?.continuationPrefix, "- [ ] ")
+		XCTAssertEqual(ListMarker(line: "- [ ] open")?.continuationPrefix, "- [ ] ")
+	}
+
+	// MARK: - Return action
+
+	private func caretAtEnd(of text: String) -> Int {
+		return (text as NSString).length
+	}
+
+	func testReturnContinuesBulletList() {
+		let text = "- item"
+		let action = ListMarker.returnAction(in: text, caret: caretAtEnd(of: text))
+		XCTAssertEqual(action, .continueList(insert: "\n- "))
+	}
+
+	func testReturnContinuesOrderedList() {
+		let text = "1. first"
+		let action = ListMarker.returnAction(in: text, caret: caretAtEnd(of: text))
+		XCTAssertEqual(action, .continueList(insert: "\n2. "))
+	}
+
+	func testReturnContinuesChecklistUnchecked() {
+		let text = "- [x] done"
+		let action = ListMarker.returnAction(in: text, caret: caretAtEnd(of: text))
+		XCTAssertEqual(action, .continueList(insert: "\n- [ ] "))
+	}
+
+	func testReturnMidContentStillContinues() {
+		// Caret between "it" and "em": splitting a list item continues the
+		// list, matching Bear/Obsidian behavior.
+		let action = ListMarker.returnAction(in: "- item", caret: 4)
+		XCTAssertEqual(action, .continueList(insert: "\n- "))
+	}
+
+	func testReturnOnEmptyItemEndsList() {
+		let text = "- first\n- "
+		let action = ListMarker.returnAction(in: text, caret: caretAtEnd(of: text))
+		XCTAssertEqual(action, .endList(remove: NSRange(location: 8, length: 2)))
+	}
+
+	func testReturnOnEmptyCheckboxEndsList() {
+		let text = "- [ ] "
+		let action = ListMarker.returnAction(in: text, caret: caretAtEnd(of: text))
+		XCTAssertEqual(action, .endList(remove: NSRange(location: 0, length: 6)))
+	}
+
+	func testReturnBeforeMarkerDoesNothing() {
+		// Caret at the line start: Return should push the item down, not
+		// spawn a marker.
+		XCTAssertEqual(ListMarker.returnAction(in: "- item", caret: 0), .none)
+		// Caret inside the marker itself.
+		XCTAssertEqual(ListMarker.returnAction(in: "- item", caret: 1), .none)
+	}
+
+	func testReturnOnPlainLineDoesNothing() {
+		let text = "just prose"
+		XCTAssertEqual(ListMarker.returnAction(in: text, caret: caretAtEnd(of: text)), .none)
+	}
+
+	func testReturnOnMiddleLineOfListUsesThatLine() {
+		// Caret at the end of the *first* line; the second line must not
+		// influence the action.
+		let text = "1. first\n2. second"
+		let action = ListMarker.returnAction(in: text, caret: 8)
+		XCTAssertEqual(action, .continueList(insert: "\n2. "))
+	}
+}

--- a/JotTests/ListMarkerTests.swift
+++ b/JotTests/ListMarkerTests.swift
@@ -148,6 +148,29 @@ final class ListMarkerTests: XCTestCase {
 		XCTAssertEqual(ListMarker.returnAction(in: text, caret: caretAtEnd(of: text)), .none)
 	}
 
+	func testReturnOnEmptyItemEndsListWithCRLF() {
+		// Windows line endings: NSString.lineRange includes the "\r\n",
+		// and a String hasSuffix("\n") check never matches it because
+		// Swift compares whole graphemes ("\r\n" is one Character). The
+		// escape hatch must still fire (2026-08 review).
+		let text = "- first\r\n- \r\n"
+		let action = ListMarker.returnAction(in: text, caret: 11)
+		XCTAssertEqual(action, .endList(remove: NSRange(location: 9, length: 2)))
+	}
+
+	func testReturnContinuesListWithCRLF() {
+		let text = "- item\r\nnext"
+		let action = ListMarker.returnAction(in: text, caret: 6)
+		XCTAssertEqual(action, .continueList(insert: "\n- "))
+	}
+
+	func testWhitespaceOnlyContentCountsAsEmptyItem() {
+		// Deliberate: "-    " is an empty item, and Return clears the
+		// whole line including the stray trailing spaces.
+		let action = ListMarker.returnAction(in: "-    ", caret: 5)
+		XCTAssertEqual(action, .endList(remove: NSRange(location: 0, length: 5)))
+	}
+
 	func testReturnOnMiddleLineOfListUsesThatLine() {
 		// Caret at the end of the *first* line; the second line must not
 		// influence the action.

--- a/JotTests/MarkdownProcessorTests.swift
+++ b/JotTests/MarkdownProcessorTests.swift
@@ -302,6 +302,64 @@ final class MarkdownProcessorTests: XCTestCase {
         XCTAssertTrue(hasTrait(storage, location: 2, trait: .boldFontMask))
     }
 
+    // MARK: - Checklists (#146)
+
+    private func strikethroughAt(_ storage: NSTextStorage, location: Int) -> Bool {
+        return storage.attribute(.strikethroughStyle, at: location, effectiveRange: nil) != nil
+    }
+
+    func testUncheckedItemDimsMarkerOnly() {
+        let storage = applyAndGetStorage("- [ ] task")
+
+        // Marker "- [ ] " is positions 0-5
+        XCTAssertEqual(colorAt(storage, location: 0), NSColor.secondaryLabelColor)
+        XCTAssertEqual(colorAt(storage, location: 5), NSColor.secondaryLabelColor)
+        // Content "task" starts at 6: normal color, no strikethrough
+        XCTAssertEqual(colorAt(storage, location: 6), NSColor.labelColor)
+        XCTAssertFalse(strikethroughAt(storage, location: 6))
+    }
+
+    func testCheckedItemIsStruckThroughAndDimmed() {
+        let storage = applyAndGetStorage("- [x] done")
+
+        XCTAssertEqual(colorAt(storage, location: 0), NSColor.secondaryLabelColor)
+        XCTAssertTrue(strikethroughAt(storage, location: 6))
+        XCTAssertEqual(colorAt(storage, location: 6), NSColor.secondaryLabelColor)
+    }
+
+    func testCheckedItemCapitalXAndIndentAlsoStyle() {
+        let storage = applyAndGetStorage("\t- [X] done")
+
+        // Content "done" starts at 7 (tab + "- [X] ")
+        XCTAssertTrue(strikethroughAt(storage, location: 7))
+        XCTAssertEqual(colorAt(storage, location: 7), NSColor.secondaryLabelColor)
+    }
+
+    func testBracketsWithoutTrailingSpaceAreNotAChecklist() {
+        let storage = applyAndGetStorage("- [x]done")
+
+        // "d" at position 5 is ordinary content of a plain bullet item
+        XCTAssertFalse(strikethroughAt(storage, location: 5))
+        XCTAssertEqual(colorAt(storage, location: 5), NSColor.labelColor)
+    }
+
+    func testCheckedItemWithEmptyContentDoesNotCrash() {
+        let storage = applyAndGetStorage("- [x] ")
+
+        XCTAssertEqual(colorAt(storage, location: 0), NSColor.secondaryLabelColor)
+    }
+
+    func testUncheckingRemovesStrikethrough() {
+        let storage = applyAndGetStorage("- [x] done")
+        XCTAssertTrue(strikethroughAt(storage, location: 6))
+
+        // Flip the state character in place, as the toggle command does,
+        // then restyle: the reset pass must clear the stale strikethrough.
+        storage.replaceCharacters(in: NSRange(location: 3, length: 1), with: " ")
+        MarkdownProcessor.applyMarkdownStyling(to: textView, using: font)
+        XCTAssertFalse(strikethroughAt(storage, location: 6))
+    }
+
     // MARK: - Nested emphasis composes (#127 follow-up)
 
     func testItalicNestedInsideBoldComposes() {

--- a/JotTests/MarkdownProcessorTests.swift
+++ b/JotTests/MarkdownProcessorTests.swift
@@ -343,6 +343,18 @@ final class MarkdownProcessorTests: XCTestCase {
         XCTAssertEqual(colorAt(storage, location: 5), NSColor.labelColor)
     }
 
+    func testCheckedItemDimsInlineStylesUniformly() {
+        // Deliberate (2026-08 review): checking an item dims the whole
+        // content — link coloring included — so the item reads as done,
+        // matching Reminders/Notes. The [x] characters still carry the
+        // state, and the .link attribute is unaffected.
+        let storage = applyAndGetStorage("- [x] see [docs](https://e.com)")
+
+        // "d" of "docs" at position 11: dimmed, not linkColor
+        XCTAssertEqual(colorAt(storage, location: 11), NSColor.secondaryLabelColor)
+        XCTAssertTrue(strikethroughAt(storage, location: 11))
+    }
+
     func testCheckedItemWithEmptyContentDoesNotCrash() {
         let storage = applyAndGetStorage("- [x] ")
 


### PR DESCRIPTION
Third of the 1.0.10 phase PRs (after #156 fixes and #165 performance). Implements the three feature issues: #143, #146, #145. Closes #143, closes #146, closes #145.

## What's in here

### List continuation on Return (#143)
Pressing Return inside a markdown list item starts the next one: bullets repeat, ordered numbers increment, checkboxes continue unchecked, indentation is preserved. Return on an empty item deletes its marker and ends the list. Return at or inside the marker falls through to a plain newline. Markdown mode only.

Parsing lives in a new `ListMarker` struct with a pure `returnAction(in:caret:)` decision function; the key handling sits in the existing `doCommandBy` delegate path next to Tab/Backtab.

### Checklists (#146)
`- [ ]` / `- [x]` markers are dimmed like other list markers; checked items are struck through and dimmed uniformly (deliberate, matches Reminders/Notes — pinned by test). Format > Toggle Checklist (⌘L) flips every checklist line the selection touches, and on selections with no checkboxes it adds them instead (plain lines get `- [ ] `, bullets get a checkbox; numbered lines are untouched). Works in both modes, like Bold/Italic. VoiceOver announces the result ("Checked 3 items", "Added 1 checklist item", "List ended" for the escape hatch).

### Paste URL over selection (#145)
In markdown mode, pasting a lone http(s) URL over a selection produces `[selection](url)`. Prose, bare domains, other schemes, multi-line or unbalanced-bracket selections, and already-link selections all fall through to a normal paste. Paste and Match Style (⌥⇧⌘V) remains the deliberate replace-instead escape.

The in-app help documents all three.

## Review

Two review agents (code quality + accessibility) ran over the branch; all findings fixed in the final commit or accounted for:
- **CRLF bug (important):** the empty-item escape hatch never fired in CRLF files — `hasSuffix("\n")` can't match a CRLF grapheme. Fixed via `getLineStart`'s `contentsEnd`, pinned with tests.
- **A11y:** the toggle command's add-when-absent behavior replaced a dimmed-mystery menu item; announcements added using the existing pattern.
- Verified clean: single-⌘Z undo on all paths, regex linearity under adversarial 1 MB inputs (#122 constraint), range-bounded styling (#123 constraint), UTF-16 caret math incl. surrogates.
- Pre-existing (not from this branch), filed as #166: markdown styling applies inside code fences.

Checkboxes don't render in the Down-based preview — GFM extension, core cmark. Deliberately not patched around; the 1.1.1 preview overhaul (#111) addresses task lists, tables, and strikethrough together.

## Testing

52 new tests (ListMarkerTests, ChecklistToggleTests via the live-editor harness, EditorTextViewTests, checklist sections in MarkdownProcessorTests). Full suite green. Hand-tested by Brian, including a VoiceOver pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Ak643B4p59MBpJyiEDsig