### PR TITLE
fix: 1.1.0 Phase 2 — small fixes and accessibility (#163, #116, #153, #152, #124)

### DIFF
--- a/Jot/App/AppDelegate.swift
+++ b/Jot/App/AppDelegate.swift
@@ -54,10 +54,13 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
 		settingsPanelController?.showWindow(sender)
 	}
 	
-	/// Show/Hide toggle: the panel never becomes key (it holds only static
-	/// labels), so Cmd-W can't close it — without a toggle, a keyboard-only
-	/// user can summon a floating panel they can only dismiss with the
-	/// mouse (#152). The menu title tracks the state in validateMenuItem.
+	/// Show/Hide toggle: the panel is built with becomesKeyOnlyIfNeeded and
+	/// holds only non-selectable labels, so nothing in it ever needs key
+	/// input and it does not take key status in normal use — which leaves
+	/// Cmd-W acting on the document window behind it. Without this toggle a
+	/// keyboard-only user can summon a floating panel and then has only the
+	/// mouse to dismiss it (#152). The menu title tracks state in
+	/// validateMenuItem.
 	@IBAction func showWordCountWindow(_ sender: Any) {
 		if wordCountPanelController == nil {
 			wordCountPanelController = WordCountPanelController()

--- a/Jot/App/AppDelegate.swift
+++ b/Jot/App/AppDelegate.swift
@@ -8,7 +8,7 @@
 import Cocoa
 
 @main
-class AppDelegate: NSObject, NSApplicationDelegate {
+class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
 	
 	var aboutWindowController: AboutWindowControllerProgrammatic?
 	var settingsPanelController: SettingsPanelController?
@@ -55,11 +55,19 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 		settingsPanelController?.showWindow(sender)
 	}
 	
+	/// Show/Hide toggle: the panel never becomes key (it holds only static
+	/// labels), so Cmd-W can't close it — without a toggle, a keyboard-only
+	/// user can summon a floating panel they can only dismiss with the
+	/// mouse (#152). The menu title tracks the state in validateMenuItem.
 	@IBAction func showWordCountWindow(_ sender: Any) {
 		if wordCountPanelController == nil {
 			wordCountPanelController = WordCountPanelController()
 		}
-		wordCountPanelController?.showWindow(sender)
+		if wordCountPanelController?.window?.isVisible == true {
+			wordCountPanelController?.window?.orderOut(sender)
+		} else {
+			wordCountPanelController?.showWindow(sender)
+		}
 	}
 	
 	@IBAction func openHelpWebsite(_ sender: Any) {
@@ -82,6 +90,15 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 	}
 
 	
+	func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {
+		if menuItem.action == #selector(showWordCountWindow(_:)) {
+			menuItem.title = (wordCountPanelController?.window?.isVisible == true)
+				? "Hide Word Count"
+				: "Show Word Count"
+		}
+		return true
+	}
+
 	func applicationDidFinishLaunching(_ aNotification: Notification) {
 		// One-time recovery of drafts left by the pre-1.0.9 hand-rolled
 		// crash-recovery system. NSDocument autosave owns crash recovery

--- a/Jot/App/AppDelegate.swift
+++ b/Jot/App/AppDelegate.swift
@@ -49,9 +49,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
 		if settingsPanelController == nil {
 			settingsPanelController = SettingsPanelController()
 		}
-		if let mainViewController = NSApplication.shared.mainWindow?.contentViewController as? EditorViewController {
-			settingsPanelController?.delegate = mainViewController
-		}
+		// No per-window wiring: font changes broadcast via
+		// FontConfiguration.didChangeNotification to every editor (#124)
 		settingsPanelController?.showWindow(sender)
 	}
 	

--- a/Jot/App/Document.swift
+++ b/Jot/App/Document.swift
@@ -15,15 +15,6 @@ class Document: NSDocument {
 	// through the main thread in practice.
 	nonisolated(unsafe) var text = ""
 
-	/// Set by the legacy migration so recovered drafts don't open as
-	/// anonymous "Untitled" windows (#153). Removed with the migration.
-	nonisolated(unsafe) var recoveredDraftName: String?
-
-	override var displayName: String! {
-		get { recoveredDraftName ?? super.displayName }
-		set { super.displayName = newValue }
-	}
-
 	// Unconditionally true: NSDocument owns autosave, crash recovery
 	// (drafts in ~/Library/Autosave Information), and the Versions
 	// browser. The user-toggleable preference and the hand-rolled
@@ -216,6 +207,7 @@ class Document: NSDocument {
 		)
 
 		var recoveredCount = 0
+		var firstRecoveredWindow: NSWindow?
 		for fileURL in files {
 			guard fileURL.pathExtension == "unsaved" else { continue }
 
@@ -251,8 +243,12 @@ class Document: NSDocument {
 			doc.text = restoredText
 			recoveredCount += 1
 			// Window title carries the context a sighted user infers and a
-			// VoiceOver user otherwise never gets (#153)
-			doc.recoveredDraftName = recoveredCount == 1
+			// VoiceOver user otherwise never gets (#153). NSDocument's own
+			// setter is used deliberately: it applies only while the document
+			// is untitled and yields to the real filename once the user saves.
+			// An overridden getter would keep saying "Recovered Draft" in the
+			// window title, save panel, and close alert forever.
+			doc.displayName = recoveredCount == 1
 				? "Recovered Draft"
 				: "Recovered Draft \(recoveredCount)"
 			// Mark edited so the draft participates in NSDocument autosave
@@ -261,24 +257,61 @@ class Document: NSDocument {
 			NSDocumentController.shared.addDocument(doc)
 			doc.makeWindowControllers()
 			doc.showWindows()
+			if firstRecoveredWindow == nil {
+				firstRecoveredWindow = doc.windowControllers.first?.window
+			}
 
 			// NSDocument autosave owns the draft from here
 			try? fm.removeItem(at: fileURL)
 		}
 
-		if recoveredCount > 0 {
-			NSAccessibility.post(
-				element: NSApp as Any,
-				notification: .announcementRequested,
-				userInfo: [.announcement: recoveredCount == 1
-					? "Recovered 1 unsaved draft from a previous session"
-					: "Recovered \(recoveredCount) unsaved drafts from a previous session"]
-			)
+		if recoveredCount > 0, let window = firstRecoveredWindow {
+			announceRecovery(of: recoveredCount, from: window)
 		}
 
 		// Best-effort removal of the now-empty legacy folder
 		if let remaining = try? fm.contentsOfDirectory(atPath: folder.path), remaining.isEmpty {
 			try? fm.removeItem(at: folder)
+		}
+	}
+
+	/// Speak the recovery notice, once the app is active and a window is key.
+	///
+	/// Three things this gets wrong if done naively (#153 follow-up):
+	/// announcements default to medium priority, which VoiceOver coalesces
+	/// away when it is already speaking — and at launch it is busy with the
+	/// app name and window title; posting during activation routes nowhere;
+	/// and posting against NSApp is unreliable, so this targets the recovered
+	/// window like every other announcement in the app.
+	private static func announceRecovery(of count: Int, from window: NSWindow) {
+		let message = count == 1
+			? "Recovered 1 unsaved draft from a previous session"
+			: "Recovered \(count) unsaved drafts from a previous session"
+
+		let post = {
+			NSAccessibility.post(
+				element: window,
+				notification: .announcementRequested,
+				userInfo: [
+					.announcement: message,
+					.priority: NSAccessibilityPriorityLevel.high.rawValue
+				]
+			)
+		}
+
+		if NSApp.isActive {
+			post()
+			return
+		}
+		// Launch case: wait for activation, then post once
+		var token: NSObjectProtocol?
+		token = NotificationCenter.default.addObserver(
+			forName: NSApplication.didBecomeActiveNotification,
+			object: NSApp,
+			queue: .main
+		) { _ in
+			if let token { NotificationCenter.default.removeObserver(token) }
+			MainActor.assumeIsolated { post() }
 		}
 	}
 }

--- a/Jot/App/Document.swift
+++ b/Jot/App/Document.swift
@@ -15,6 +15,15 @@ class Document: NSDocument {
 	// through the main thread in practice.
 	nonisolated(unsafe) var text = ""
 
+	/// Set by the legacy migration so recovered drafts don't open as
+	/// anonymous "Untitled" windows (#153). Removed with the migration.
+	nonisolated(unsafe) var recoveredDraftName: String?
+
+	override var displayName: String! {
+		get { recoveredDraftName ?? super.displayName }
+		set { super.displayName = newValue }
+	}
+
 	// Unconditionally true: NSDocument owns autosave, crash recovery
 	// (drafts in ~/Library/Autosave Information), and the Versions
 	// browser. The user-toggleable preference and the hand-rolled
@@ -206,6 +215,7 @@ class Document: NSDocument {
 				.compactMap { ($0 as? Document)?.fileURL?.path }
 		)
 
+		var recoveredCount = 0
 		for fileURL in files {
 			guard fileURL.pathExtension == "unsaved" else { continue }
 
@@ -239,6 +249,12 @@ class Document: NSDocument {
 
 			let doc = Document()
 			doc.text = restoredText
+			recoveredCount += 1
+			// Window title carries the context a sighted user infers and a
+			// VoiceOver user otherwise never gets (#153)
+			doc.recoveredDraftName = recoveredCount == 1
+				? "Recovered Draft"
+				: "Recovered Draft \(recoveredCount)"
 			// Mark edited so the draft participates in NSDocument autosave
 			// and closing the window prompts to save (#120)
 			doc.updateChangeCount(.changeDone)
@@ -248,6 +264,16 @@ class Document: NSDocument {
 
 			// NSDocument autosave owns the draft from here
 			try? fm.removeItem(at: fileURL)
+		}
+
+		if recoveredCount > 0 {
+			NSAccessibility.post(
+				element: NSApp as Any,
+				notification: .announcementRequested,
+				userInfo: [.announcement: recoveredCount == 1
+					? "Recovered 1 unsaved draft from a previous session"
+					: "Recovered \(recoveredCount) unsaved drafts from a previous session"]
+			)
 		}
 
 		// Best-effort removal of the now-empty legacy folder

--- a/Jot/Editor/EditorViewController.swift
+++ b/Jot/Editor/EditorViewController.swift
@@ -28,6 +28,11 @@ class EditorViewController: NSViewController, NSTextViewDelegate {
 	var selectedFont: NSFont?
 	var selectedFontSize: CGFloat?
 	var currentMode: EditorMode = .plainText
+
+	/// Per-window Bigger/Smaller zoom, or nil when this window follows the
+	/// global Settings size. Kept separate from selectedFontSize so "is this
+	/// window zoomed?" is answerable — which is what Actual Size needs.
+	private var zoomOverrideSize: CGFloat?
 	
 	override func viewDidLoad() {
 		super.viewDidLoad()
@@ -48,20 +53,31 @@ class EditorViewController: NSViewController, NSTextViewDelegate {
 			scrollView.contentView.postsBoundsChangedNotifications = true
 		}
 
+	}
+
+	override func viewWillAppear() {
+		super.viewWillAppear()
 		// Font changes broadcast to every window; the old 1:1 delegate
-		// reached only whichever window was main when Settings opened (#124)
+		// reached only whichever window was main when Settings opened (#124).
+		// Registered here rather than in viewDidLoad because
+		// viewWillDisappear tears it down, and a window that is hidden and
+		// shown again must go back to following Settings. Removed first so a
+		// second appearance doesn't leave two registrations restyling twice.
+		NotificationCenter.default.removeObserver(
+			self, name: FontConfiguration.didChangeNotification, object: nil)
 		NotificationCenter.default.addObserver(
 			self,
 			selector: #selector(fontConfigurationDidChange),
 			name: FontConfiguration.didChangeNotification,
-			object: nil
+			object: FontConfiguration.shared
 		)
 	}
 
 	@objc private func fontConfigurationDidChange(_ notification: Notification) {
-		// Deliberately overwrites any Bigger/Smaller zoom: a Settings
-		// change snaps every window to the new global — predictable, and
-		// a reset-zoom-everywhere gesture for free
+		// Deliberately clears any Bigger/Smaller zoom: a Settings change
+		// snaps every window to the new global — predictable, and a
+		// reset-zoom-everywhere gesture for free
+		zoomOverrideSize = nil
 		let fontConfig = FontConfiguration.shared
 		selectedFont = fontConfig.resolvedFont()
 		selectedFontSize = fontConfig.currentSize
@@ -86,6 +102,18 @@ class EditorViewController: NSViewController, NSTextViewDelegate {
 		wordCountUpdateTimer = nil
 		visibleRangeStyleTimer?.invalidate()
 		visibleRangeStyleTimer = nil
+
+		// Same reason the timers stop here: a font change arriving between
+		// window close and dealloc would run a full styling pass over a text
+		// view AppKit is tearing down.
+		NotificationCenter.default.removeObserver(
+			self, name: FontConfiguration.didChangeNotification, object: nil)
+	}
+
+	deinit {
+		// Backstop for the scroll observer and any path that skips
+		// viewWillDisappear. Matches WordCountPanelController.
+		NotificationCenter.default.removeObserver(self)
 	}
 
 	@objc private func scrollViewDidScroll(_ notification: Notification) {
@@ -132,32 +160,142 @@ class EditorViewController: NSViewController, NSTextViewDelegate {
 	// size), new windows open at the global size, and a Settings change
 	// resets every window's override via the broadcast (#124 follow-up).
 
+	/// Below ~6 pt the text is unreadable and hard to recover from; above
+	/// ~288 pt a single glyph fills the window and every keystroke pays for
+	/// a full styling pass.
+	private static let minimumZoomSize: CGFloat = 6
+	private static let maximumZoomSize: CGFloat = 288
+
 	@IBAction func increaseFontSize(_ sender: Any) {
-		setWindowFontSize(currentWindowFontSize() + 1)
+		setWindowFontSize(min(currentWindowFontSize() + 1, Self.maximumZoomSize))
 	}
 
 	@IBAction func decreaseFontSize(_ sender: Any) {
-		// Floor: below ~6 pt the text is unreadable and hard to recover from
-		setWindowFontSize(max(currentWindowFontSize() - 1, 6))
+		setWindowFontSize(max(currentWindowFontSize() - 1, Self.minimumZoomSize))
+	}
+
+	/// Format > Actual Size (Cmd-0): drop this window's zoom and follow the
+	/// global again. Without it the only way back is a Settings round-trip,
+	/// which is a bad ask of someone who just zoomed down to 6 pt.
+	@IBAction func resetFontSize(_ sender: Any) {
+		guard zoomOverrideSize != nil else { return }
+		zoomOverrideSize = nil
+		applyWindowFont(FontConfiguration.shared.resolvedFont())
+		selectedFontSize = FontConfiguration.shared.currentSize
+		announceForAccessibility("Actual size, \(Int(FontConfiguration.shared.currentSize)) point")
 	}
 
 	private func currentWindowFontSize() -> CGFloat {
-		return selectedFontSize ?? FontConfiguration.shared.currentSize
+		return zoomOverrideSize ?? FontConfiguration.shared.currentSize
 	}
 
 	private func setWindowFontSize(_ size: CGFloat) {
+		guard size != currentWindowFontSize() else { return }
+		zoomOverrideSize = size
 		selectedFontSize = size
-		let base = selectedFont ?? FontConfiguration.shared.resolvedFont()
-		selectedFont = NSFont(descriptor: base.fontDescriptor, size: size)
-			?? NSFont.systemFont(ofSize: size)
-		textView.font = selectedFont
+		// Derive from the global font, not from the already-zoomed one, so
+		// repeated presses don't compound descriptor derivations
+		let base = FontConfiguration.shared.resolvedFont()
+		applyWindowFont(NSFont(descriptor: base.fontDescriptor, size: size)
+			?? NSFont.systemFont(ofSize: size))
+		// Cmd-+ is a low-vision accommodation; a magnifier or VoiceOver user
+		// needs the result spoken, not inferred from the screen
+		announceForAccessibility("Text size \(Int(size)) point")
+	}
+
+	private func applyWindowFont(_ font: NSFont) {
+		selectedFont = font
+		textView.font = font
 		// Recorded styling carries the old size (#139)
 		styledCharacters.removeAll()
 		if currentMode == .markdown {
 			applyStyling()
 		}
+		invalidateRestorableState()
 	}
 	
+	// MARK: - State restoration
+
+	// The app returns true from applicationSupportsSecureRestorableState, so
+	// macOS restores windows on relaunch — but nothing was encoded, and a
+	// restored window came back in plain-text mode at the top of the document
+	// with the caret at zero. AppKit calls these on NSViewController for any
+	// controller reachable from a restorable window.
+
+	private enum RestorationKey {
+		static let mode = "jot.editorMode"
+		static let zoom = "jot.zoomOverrideSize"
+		static let selection = "jot.selectedRange"
+		static let scrollOrigin = "jot.scrollOrigin"
+	}
+
+	override func encodeRestorableState(with coder: NSCoder) {
+		super.encodeRestorableState(with: coder)
+		coder.encode(currentMode == .markdown, forKey: RestorationKey.mode)
+		// Zoom is per-window and temporary, but "temporary" should mean
+		// "until you reset it," not "until you quit" — a restored window
+		// looks identical to the one you closed, so silently dropping the
+		// zoom reads as a bug.
+		if let zoom = zoomOverrideSize {
+			coder.encode(Double(zoom), forKey: RestorationKey.zoom)
+		}
+		coder.encode(NSStringFromRange(textView.selectedRange()), forKey: RestorationKey.selection)
+		if let clipView = textView.enclosingScrollView?.contentView {
+			coder.encode(NSStringFromPoint(clipView.bounds.origin), forKey: RestorationKey.scrollOrigin)
+		}
+	}
+
+	override func restoreState(with coder: NSCoder) {
+		super.restoreState(with: coder)
+
+		if coder.containsValue(forKey: RestorationKey.zoom) {
+			let size = CGFloat(coder.decodeDouble(forKey: RestorationKey.zoom))
+			// Clamp: a preferences file edited by hand (or written by a
+			// future build with different limits) must not restore a window
+			// to an unreadable size
+			if size >= Self.minimumZoomSize && size <= Self.maximumZoomSize {
+				zoomOverrideSize = size
+				selectedFontSize = size
+				let base = FontConfiguration.shared.resolvedFont()
+				selectedFont = NSFont(descriptor: base.fontDescriptor, size: size)
+					?? NSFont.systemFont(ofSize: size)
+				textView.font = selectedFont
+			}
+		}
+
+		// Mode last of the two: it runs the styling pass, so it should see
+		// the restored font rather than restyle twice
+		let wasMarkdown = coder.decodeBool(forKey: RestorationKey.mode)
+		currentMode = wasMarkdown ? .markdown : .plainText
+		styledCharacters.removeAll()
+		if currentMode == .markdown {
+			applyStyling()
+		} else {
+			removeMarkdownStyling()
+		}
+		modePopUpButton.selectItem(withTitle: wasMarkdown ? "Markdown" : "Plain Text")
+
+		if let selectionString = coder.decodeObject(of: NSString.self, forKey: RestorationKey.selection) {
+			let range = NSRangeFromString(selectionString as String)
+			// The document may have been edited elsewhere between sessions
+			let length = (textView.string as NSString).length
+			if range.location <= length && NSMaxRange(range) <= length {
+				textView.setSelectedRange(range)
+			}
+		}
+
+		if let originString = coder.decodeObject(of: NSString.self, forKey: RestorationKey.scrollOrigin) {
+			let origin = NSPointFromString(originString as String)
+			// After layout, or the clip view clamps to a document height it
+			// doesn't have yet and the scroll lands at the top
+			DispatchQueue.main.async { [weak self] in
+				guard let scrollView = self?.textView.enclosingScrollView else { return }
+				scrollView.contentView.scroll(to: origin)
+				scrollView.reflectScrolledClipView(scrollView.contentView)
+			}
+		}
+	}
+
 	@IBAction func toggleEditorMode(_ sender: Any) {
 		currentMode = (currentMode == .markdown) ? .plainText : .markdown
 
@@ -168,6 +306,7 @@ class EditorViewController: NSViewController, NSTextViewDelegate {
 		}
 
 		updateModeUI()
+		invalidateRestorableState()
 	}
 	
 	func updateModeUI() {
@@ -726,6 +865,17 @@ extension EditorViewController: NSMenuItemValidation {
 			// Disabled only when there is nothing to flip or add — in
 			// practice, when the selection is entirely numbered-list items
 			return selectionHasChecklistWork()
+		}
+		if menuItem.action == #selector(resetFontSize(_:)) {
+			// Dimmed when this window already follows the global size, so
+			// the menu answers "is this window zoomed?"
+			return zoomOverrideSize != nil
+		}
+		if menuItem.action == #selector(increaseFontSize(_:)) {
+			return currentWindowFontSize() < Self.maximumZoomSize
+		}
+		if menuItem.action == #selector(decreaseFontSize(_:)) {
+			return currentWindowFontSize() > Self.minimumZoomSize
 		}
 		// Every other action this controller exposes stays enabled, which
 		// is what AppKit did before this method existed.

--- a/Jot/Editor/EditorViewController.swift
+++ b/Jot/Editor/EditorViewController.swift
@@ -8,7 +8,7 @@
 import Cocoa
 import os.signpost
 
-class EditorViewController: NSViewController, NSTextViewDelegate, TextSettingsDelegate {
+class EditorViewController: NSViewController, NSTextViewDelegate {
 	
 	@IBOutlet var textView: NSTextView!
 	@IBOutlet var wordCountLabel: NSTextField!
@@ -46,6 +46,28 @@ class EditorViewController: NSViewController, NSTextViewDelegate, TextSettingsDe
 				object: scrollView.contentView
 			)
 			scrollView.contentView.postsBoundsChangedNotifications = true
+		}
+
+		// Font changes broadcast to every window; the old 1:1 delegate
+		// reached only whichever window was main when Settings opened (#124)
+		NotificationCenter.default.addObserver(
+			self,
+			selector: #selector(fontConfigurationDidChange),
+			name: FontConfiguration.didChangeNotification,
+			object: nil
+		)
+	}
+
+	@objc private func fontConfigurationDidChange(_ notification: Notification) {
+		let fontConfig = FontConfiguration.shared
+		selectedFont = fontConfig.resolvedFont()
+		selectedFontSize = fontConfig.currentSize
+		textView.font = selectedFont
+		// Recorded styling carries the old font; restyle now instead of
+		// leaving the document half-styled until the next edit (#139)
+		styledCharacters.removeAll()
+		if currentMode == .markdown {
+			applyStyling()
 		}
 	}
 
@@ -93,23 +115,7 @@ class EditorViewController: NSViewController, NSTextViewDelegate, TextSettingsDe
 		}
 	}
 	
-	// MARK: - Text Settings Delegate
-	func didSelectFont(_ font: NSFont) {
-		let fontConfig = FontConfiguration.shared
-		fontConfig.applyFont(font)
-		selectedFont = fontConfig.resolvedFont()
-		textView.font = selectedFont
-		styledCharacters.removeAll()
-	}
-
-	func didSelectFontSize(_ fontSize: CGFloat) {
-		let fontConfig = FontConfiguration.shared
-		fontConfig.applySize(fontSize)
-		selectedFontSize = fontSize
-		selectedFont = fontConfig.resolvedFont()
-		textView.font = selectedFont
-		styledCharacters.removeAll()
-	}
+	// MARK: - Font
 
 	func loadFontPreferences() {
 		let fontConfig = FontConfiguration.shared
@@ -118,8 +124,17 @@ class EditorViewController: NSViewController, NSTextViewDelegate, TextSettingsDe
 		textView.font = selectedFont
 	}
 
-	func currentFontSize() -> CGFloat {
-		return FontConfiguration.shared.currentSize
+	// Format > Bigger/Smaller route through FontConfiguration so the size
+	// persists and every window updates — the old NSFontManager.modifyFont:
+	// wiring resized one window's text without persisting anything (#124)
+
+	@IBAction func increaseFontSize(_ sender: Any) {
+		FontConfiguration.shared.applySize(FontConfiguration.shared.currentSize + 1)
+	}
+
+	@IBAction func decreaseFontSize(_ sender: Any) {
+		// Floor: below ~6 pt the text is unreadable and hard to recover from
+		FontConfiguration.shared.applySize(max(FontConfiguration.shared.currentSize - 1, 6))
 	}
 	
 	@IBAction func toggleEditorMode(_ sender: Any) {

--- a/Jot/Editor/EditorViewController.swift
+++ b/Jot/Editor/EditorViewController.swift
@@ -59,6 +59,9 @@ class EditorViewController: NSViewController, NSTextViewDelegate {
 	}
 
 	@objc private func fontConfigurationDidChange(_ notification: Notification) {
+		// Deliberately overwrites any Bigger/Smaller zoom: a Settings
+		// change snaps every window to the new global — predictable, and
+		// a reset-zoom-everywhere gesture for free
 		let fontConfig = FontConfiguration.shared
 		selectedFont = fontConfig.resolvedFont()
 		selectedFontSize = fontConfig.currentSize
@@ -124,17 +127,35 @@ class EditorViewController: NSViewController, NSTextViewDelegate {
 		textView.font = selectedFont
 	}
 
-	// Format > Bigger/Smaller route through FontConfiguration so the size
-	// persists and every window updates — the old NSFontManager.modifyFont:
-	// wiring resized one window's text without persisting anything (#124)
+	// Format > Bigger/Smaller: a per-window, temporary zoom — display
+	// only. The Settings font stays the global default (and the print
+	// size), new windows open at the global size, and a Settings change
+	// resets every window's override via the broadcast (#124 follow-up).
 
 	@IBAction func increaseFontSize(_ sender: Any) {
-		FontConfiguration.shared.applySize(FontConfiguration.shared.currentSize + 1)
+		setWindowFontSize(currentWindowFontSize() + 1)
 	}
 
 	@IBAction func decreaseFontSize(_ sender: Any) {
 		// Floor: below ~6 pt the text is unreadable and hard to recover from
-		FontConfiguration.shared.applySize(max(FontConfiguration.shared.currentSize - 1, 6))
+		setWindowFontSize(max(currentWindowFontSize() - 1, 6))
+	}
+
+	private func currentWindowFontSize() -> CGFloat {
+		return selectedFontSize ?? FontConfiguration.shared.currentSize
+	}
+
+	private func setWindowFontSize(_ size: CGFloat) {
+		selectedFontSize = size
+		let base = selectedFont ?? FontConfiguration.shared.resolvedFont()
+		selectedFont = NSFont(descriptor: base.fontDescriptor, size: size)
+			?? NSFont.systemFont(ofSize: size)
+		textView.font = selectedFont
+		// Recorded styling carries the old size (#139)
+		styledCharacters.removeAll()
+		if currentMode == .markdown {
+			applyStyling()
+		}
 	}
 	
 	@IBAction func toggleEditorMode(_ sender: Any) {

--- a/Jot/Editor/FontConfiguration.swift
+++ b/Jot/Editor/FontConfiguration.swift
@@ -33,17 +33,32 @@ class FontConfiguration {
         self.currentSize = size
     }
 
+    /// Posted after any font or size change. Every editor window and the
+    /// Settings preview observe this — the old 1:1 delegate reached only
+    /// whichever window was main when Settings opened (#124).
+    static let didChangeNotification = Notification.Name("JotFontConfigurationDidChange")
+
+    /// Adopts the font and its own point size in one change (a font-panel
+    /// pick carries both), posting a single notification.
     func applyFont(_ font: NSFont) {
-        currentFont = NSFont(descriptor: font.fontDescriptor, size: currentSize)
-            ?? NSFont.systemFont(ofSize: currentSize)
         PreferencesManager.shared.fontName = font.fontName
+        apply(font: font, size: font.pointSize)
     }
 
     func applySize(_ size: CGFloat) {
+        apply(font: currentFont, size: size)
+    }
+
+    /// Single mutation point. fontName persistence stays in applyFont —
+    /// a size-only change must not write the system font's dot-prefixed
+    /// name into preferences, because NSFont(name:) round-trips those
+    /// unreliably across OS versions.
+    private func apply(font: NSFont, size: CGFloat) {
         currentSize = size
-        currentFont = NSFont(descriptor: currentFont.fontDescriptor, size: size)
+        currentFont = NSFont(descriptor: font.fontDescriptor, size: size)
             ?? NSFont.systemFont(ofSize: size)
         PreferencesManager.shared.fontSize = size
+        NotificationCenter.default.post(name: FontConfiguration.didChangeNotification, object: self)
     }
 
     func resolvedFont() -> NSFont {

--- a/Jot/Markdown/MarkdownProcessor.swift
+++ b/Jot/Markdown/MarkdownProcessor.swift
@@ -296,6 +296,12 @@ enum MarkdownProcessor {
 
 			guard sepRange.location > 0 else { return }
 			let headerLineRange = (string as NSString).lineRange(for: NSRange(location: sepRange.location - 1, length: 0))
+			// A bounded pass must not write outside its own range (#163):
+			// the reset pass only covered `range`, so bolding a header line
+			// beyond it would plant attributes no reset will ever clean.
+			// The debounced visible-range pass re-bolds the header within
+			// ~0.3 s of a keystroke on the separator line.
+			guard NSIntersectionRange(headerLineRange, range).length > 0 else { return }
 			let headerContent = (string as NSString).substring(with: headerLineRange)
 			if headerContent.contains("|") {
 				textStorage.addAttribute(.font, value: boldFont, range: headerLineRange)

--- a/Jot/Resources/Base.lproj/Main.storyboard
+++ b/Jot/Resources/Base.lproj/Main.storyboard
@@ -372,6 +372,11 @@
                                                             <action selector="decreaseFontSize:" target="Ady-hI-5gd" id="HcX-Lf-eNd"/>
                                                         </connections>
                                                     </menuItem>
+                                                    <menuItem title="Actual Size" keyEquivalent="0" id="aSz-mi-001">
+                                                        <connections>
+                                                            <action selector="resetFontSize:" target="Ady-hI-5gd" id="aSz-ac-001"/>
+                                                        </connections>
+                                                    </menuItem>
                                                     <menuItem isSeparatorItem="YES" id="kx3-Dk-x3B"/>
                                                     <menuItem title="Kern" id="jBQ-r6-VK2">
                                                         <modifierMask key="keyEquivalentModifierMask"/>

--- a/Jot/Resources/Base.lproj/Main.storyboard
+++ b/Jot/Resources/Base.lproj/Main.storyboard
@@ -362,14 +362,14 @@
                                                         </connections>
                                                     </menuItem>
                                                     <menuItem isSeparatorItem="YES" id="5gT-KC-WSO"/>
-                                                    <menuItem title="Bigger" tag="3" keyEquivalent="+" id="Ptp-SP-VEL">
+                                                    <menuItem title="Bigger" keyEquivalent="+" id="Ptp-SP-VEL">
                                                         <connections>
-                                                            <action selector="modifyFont:" target="YLy-65-1bz" id="Uc7-di-UnL"/>
+                                                            <action selector="increaseFontSize:" target="Ady-hI-5gd" id="Uc7-di-UnL"/>
                                                         </connections>
                                                     </menuItem>
-                                                    <menuItem title="Smaller" tag="4" keyEquivalent="-" id="i1d-Er-qST">
+                                                    <menuItem title="Smaller" keyEquivalent="-" id="i1d-Er-qST">
                                                         <connections>
-                                                            <action selector="modifyFont:" target="YLy-65-1bz" id="HcX-Lf-eNd"/>
+                                                            <action selector="decreaseFontSize:" target="Ady-hI-5gd" id="HcX-Lf-eNd"/>
                                                         </connections>
                                                     </menuItem>
                                                     <menuItem isSeparatorItem="YES" id="kx3-Dk-x3B"/>

--- a/Jot/Windows/HelpViewController.swift
+++ b/Jot/Windows/HelpViewController.swift
@@ -19,7 +19,27 @@ class HelpViewController: NSViewController, WKNavigationDelegate {
 	}
 
 	func loadHelpFile(named fileName: String) {
-		guard let filePath = Bundle.main.path(forResource: fileName, ofType: "html") else { return }
+		guard let filePath = Bundle.main.path(forResource: fileName, ofType: "html") else {
+			// A build-phase mistake (target membership, a rename) would
+			// otherwise ship as a silently blank window (#116)
+			assertionFailure("Help resource \(fileName).html is missing from the bundle")
+			webView.loadHTMLString("""
+				<!DOCTYPE html>
+				<html>
+				<head>
+				<meta charset="utf-8">
+				<meta name="color-scheme" content="light dark">
+				</head>
+				<body style="font-family: -apple-system; margin: 2em;">
+				<h1>Help unavailable</h1>
+				<p>The help content could not be loaded. Please
+				<a href="mailto:brian.goodwin@protonmail.com">email the developer</a>
+				to report this.</p>
+				</body>
+				</html>
+				""", baseURL: nil)
+			return
+		}
 
 		let fileURL = URL(fileURLWithPath: filePath)
 		webView.loadFileURL(fileURL, allowingReadAccessTo: fileURL.deletingLastPathComponent())

--- a/Jot/Windows/SettingsPanelController.swift
+++ b/Jot/Windows/SettingsPanelController.swift
@@ -8,19 +8,11 @@
 
 import Cocoa
 
-@MainActor protocol TextSettingsDelegate: AnyObject {
-    func didSelectFont(_ font: NSFont)
-    func didSelectFontSize(_ fontSize: CGFloat)
-    func currentFontSize() -> CGFloat
-}
-
 @MainActor
 class SettingsPanelController: NSWindowController, NSWindowDelegate {
 
     private var fontPreviewLabel: NSTextField!
     private var remoteImagesPopup: NSPopUpButton!
-
-    weak var delegate: TextSettingsDelegate?
 
     // MARK: - Initialization
 
@@ -40,6 +32,19 @@ class SettingsPanelController: NSWindowController, NSWindowDelegate {
         window.delegate = self
         setupContentView()
         loadCurrentValues()
+
+        // Keep the preview current when the font changes from anywhere
+        // (Format > Bigger/Smaller included), not just this panel (#124)
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(fontConfigurationDidChange),
+            name: FontConfiguration.didChangeNotification,
+            object: nil
+        )
+    }
+
+    @objc private func fontConfigurationDidChange(_ notification: Notification) {
+        updateFontPreview(FontConfiguration.shared.resolvedFont())
     }
 
     override init(window: NSWindow?) {
@@ -167,9 +172,11 @@ class SettingsPanelController: NSWindowController, NSWindowDelegate {
         let currentFont = FontConfiguration.shared.currentFont
         let newFont = sender.convert(currentFont)
 
-        delegate?.didSelectFont(newFont)
-        delegate?.didSelectFontSize(newFont.pointSize)
-        updateFontPreview(newFont)
+        // Write the shared configuration directly: persistence no longer
+        // depends on an editor window being open, and the change
+        // notification reaches every window (#124). The preview label
+        // updates via the same notification.
+        FontConfiguration.shared.applyFont(newFont)
     }
 
     @objc private func remoteImagesChanged(_ sender: NSPopUpButton) {

--- a/Jot/Windows/SettingsPanelController.swift
+++ b/Jot/Windows/SettingsPanelController.swift
@@ -32,27 +32,39 @@ class SettingsPanelController: NSWindowController, NSWindowDelegate {
         window.delegate = self
         setupContentView()
         loadCurrentValues()
-
-        // Keep the preview current when the font changes from anywhere
-        // (Format > Bigger/Smaller included), not just this panel (#124)
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(fontConfigurationDidChange),
-            name: FontConfiguration.didChangeNotification,
-            object: nil
-        )
     }
 
     @objc private func fontConfigurationDidChange(_ notification: Notification) {
         updateFontPreview(FontConfiguration.shared.resolvedFont())
     }
 
+    /// Registered from every initializer, not just convenience init(): a
+    /// panel built through init(window:) or init?(coder:) would otherwise
+    /// have a preview that silently never updates, hidden by the
+    /// loadCurrentValues() call in showWindow (#124).
+    private func observeFontConfiguration() {
+        // Keep the preview current when the font changes from anywhere,
+        // not just this panel
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(fontConfigurationDidChange),
+            name: FontConfiguration.didChangeNotification,
+            object: FontConfiguration.shared
+        )
+    }
+
     override init(window: NSWindow?) {
         super.init(window: window)
+        observeFontConfiguration()
     }
 
     required init?(coder: NSCoder) {
         super.init(coder: coder)
+        observeFontConfiguration()
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
     }
 
     // MARK: - View Setup

--- a/JotTests/DocumentTests.swift
+++ b/JotTests/DocumentTests.swift
@@ -325,6 +325,41 @@ final class DocumentTests: XCTestCase {
         }
     }
 
+    func testRecoveredDraftTakesItsFilenameOnceSaved() throws {
+        try withLegacyStateFolder { tempFolder in
+            let marker = "saved-draft-\(UUID().uuidString)"
+            let stateURL = tempFolder.appendingPathComponent("untitled.unsaved")
+            try marker.write(to: stateURL, atomically: true, encoding: .utf8)
+
+            Document.performLegacyMigration()
+
+            let restored = try XCTUnwrap(
+                NSDocumentController.shared.documents
+                    .compactMap { $0 as? Document }
+                    .first { $0.text == marker }
+            )
+            defer { restored.close() }
+            XCTAssertEqual(restored.displayName, "Recovered Draft")
+
+            // An overridden displayName getter would keep saying "Recovered
+            // Draft" here — in the window title, the save panel, the close
+            // alert, and the Word Count panel — for the life of the document
+            // Save outside tempFolder: the migration removes that folder once
+            // it is empty, and withLegacyStateFolder cleans it up afterward
+            let saveFolder = URL(fileURLWithPath: NSTemporaryDirectory())
+                .appendingPathComponent("JotSaveTest-\(UUID().uuidString)", isDirectory: true)
+            try FileManager.default.createDirectory(at: saveFolder, withIntermediateDirectories: true)
+            defer { try? FileManager.default.removeItem(at: saveFolder) }
+
+            let savedURL = saveFolder.appendingPathComponent("chapter-3.txt")
+            try restored.text.write(to: savedURL, atomically: true, encoding: .utf8)
+            restored.fileURL = savedURL
+
+            XCTAssertEqual(restored.displayName, "chapter-3.txt",
+                           "a saved draft must show its real filename, not the recovery placeholder")
+        }
+    }
+
     func testMigrationStripsPathSentinel() throws {
         try withLegacyStateFolder { tempFolder in
             let marker = "named-\(UUID().uuidString)"

--- a/JotTests/DocumentTests.swift
+++ b/JotTests/DocumentTests.swift
@@ -306,6 +306,25 @@ final class DocumentTests: XCTestCase {
         }
     }
 
+    func testMigrationNamesRecoveredDrafts() throws {
+        try withLegacyStateFolder { tempFolder in
+            let marker = "named-draft-\(UUID().uuidString)"
+            let stateURL = tempFolder.appendingPathComponent("untitled.unsaved")
+            try marker.write(to: stateURL, atomically: true, encoding: .utf8)
+
+            Document.performLegacyMigration()
+
+            let restored = NSDocumentController.shared.documents
+                .compactMap { $0 as? Document }
+                .first { $0.text == marker }
+            defer { restored?.close() }
+
+            // The window title carries the recovery context instead of an
+            // anonymous "Untitled" (#153)
+            XCTAssertEqual(restored?.displayName, "Recovered Draft")
+        }
+    }
+
     func testMigrationStripsPathSentinel() throws {
         try withLegacyStateFolder { tempFolder in
             let marker = "named-\(UUID().uuidString)"

--- a/JotTests/FontBroadcastTests.swift
+++ b/JotTests/FontBroadcastTests.swift
@@ -90,18 +90,52 @@ final class FontBroadcastTests: XCTestCase {
 		}
 	}
 
-	func testIncreaseAndDecreaseFontSizeActions() throws {
+	// MARK: - Bigger/Smaller: per-window temporary zoom (#124 follow-up)
+
+	func testBiggerIsAPerWindowOverride() throws {
+		try withSavedFontPreferences {
+			let (doc1, editor1) = try makeEditor()
+			defer { doc1.close() }
+			let (doc2, editor2) = try makeEditor()
+			defer { doc2.close() }
+
+			let globalSize = FontConfiguration.shared.currentSize
+			let persistedSize = PreferencesManager.shared.fontSize
+			editor1.increaseFontSize(self)
+
+			XCTAssertEqual(editor1.textView.font?.pointSize, globalSize + 1)
+			// Display-only: the other window, the shared configuration,
+			// and the persisted preference are all untouched
+			XCTAssertEqual(editor2.textView.font?.pointSize, globalSize)
+			XCTAssertEqual(FontConfiguration.shared.currentSize, globalSize)
+			XCTAssertEqual(PreferencesManager.shared.fontSize, persistedSize)
+		}
+	}
+
+	func testSmallerFloorsAtSixPoints() throws {
 		try withSavedFontPreferences {
 			let (doc, editor) = try makeEditor()
 			defer { doc.close() }
 
-			let start = FontConfiguration.shared.currentSize
-			editor.increaseFontSize(self)
-			XCTAssertEqual(FontConfiguration.shared.currentSize, start + 1)
-			XCTAssertEqual(PreferencesManager.shared.fontSize, start + 1)
+			for _ in 0..<50 { editor.decreaseFontSize(self) }
+			XCTAssertEqual(editor.textView.font?.pointSize, 6)
+		}
+	}
 
-			editor.decreaseFontSize(self)
-			XCTAssertEqual(FontConfiguration.shared.currentSize, start)
+	func testSettingsChangeResetsWindowZoom() throws {
+		try withSavedFontPreferences {
+			let (doc, editor) = try makeEditor()
+			defer { doc.close() }
+
+			editor.increaseFontSize(self)
+			editor.increaseFontSize(self)
+
+			// A global change snaps the window back — deliberate: Settings
+			// doubles as reset-zoom-everywhere
+			let newGlobal = FontConfiguration.shared.currentSize + 5
+			FontConfiguration.shared.applySize(newGlobal)
+
+			XCTAssertEqual(editor.textView.font?.pointSize, newGlobal)
 		}
 	}
 }

--- a/JotTests/FontBroadcastTests.swift
+++ b/JotTests/FontBroadcastTests.swift
@@ -1,0 +1,107 @@
+//
+//  FontBroadcastTests.swift
+//  JotTests
+//
+//  Tests for the font-change broadcast (#124): FontConfiguration changes
+//  must reach every open editor and persist without one, replacing the
+//  1:1 delegate that only updated whichever window was main when
+//  Settings opened.
+//
+
+import XCTest
+@testable import Jot
+
+@MainActor
+final class FontBroadcastTests: XCTestCase {
+
+	// FontConfiguration persists through UserDefaults.standard. Each test
+	// wraps itself in this so the developer's real preferences survive;
+	// no stored fixtures — XCTest's setUp is nonisolated under Swift 6
+	// (same reasoning as EditorFormattingTests).
+	private func withSavedFontPreferences(_ body: () throws -> Void) rethrows {
+		let savedFontName = PreferencesManager.shared.fontName
+		let savedFontSize = PreferencesManager.shared.fontSize
+		let savedConfigSize = FontConfiguration.shared.currentSize
+		defer {
+			FontConfiguration.shared.applySize(savedConfigSize)
+			PreferencesManager.shared.fontName = savedFontName
+			PreferencesManager.shared.fontSize = savedFontSize
+		}
+		try body()
+	}
+
+	private func makeEditor() throws -> (Document, EditorViewController) {
+		let document = Document()
+		document.makeWindowControllers()
+		let editor = try XCTUnwrap(
+			document.windowControllers.first?.contentViewController as? EditorViewController
+		)
+		return (document, editor)
+	}
+
+	func testSizeChangeReachesEveryOpenEditor() throws {
+		try withSavedFontPreferences {
+			let (doc1, editor1) = try makeEditor()
+			defer { doc1.close() }
+			let (doc2, editor2) = try makeEditor()
+			defer { doc2.close() }
+
+			let newSize = FontConfiguration.shared.currentSize + 3
+			FontConfiguration.shared.applySize(newSize)
+
+			XCTAssertEqual(editor1.textView.font?.pointSize, newSize)
+			XCTAssertEqual(editor2.textView.font?.pointSize, newSize)
+		}
+	}
+
+	func testSizeChangePersistsWithoutAnyEditorOpen() {
+		withSavedFontPreferences {
+			let newSize = FontConfiguration.shared.currentSize + 2
+			FontConfiguration.shared.applySize(newSize)
+
+			XCTAssertEqual(PreferencesManager.shared.fontSize, newSize)
+		}
+	}
+
+	func testSizeOnlyChangeDoesNotPersistAFontName() {
+		withSavedFontPreferences {
+			// A user who never chose a font must not get the system font's
+			// dot-prefixed name written into preferences — NSFont(name:)
+			// round-trips those unreliably across OS versions.
+			PreferencesManager.shared.fontName = nil
+			FontConfiguration.shared.applySize(FontConfiguration.shared.currentSize + 1)
+
+			XCTAssertNil(PreferencesManager.shared.fontName)
+		}
+	}
+
+	func testFontChangePostsExactlyOneNotification() {
+		withSavedFontPreferences {
+			// applyFont adopts font and size together: one change, one
+			// restyle. assertForOverFulfill catches a double post.
+			let expectation = XCTNSNotificationExpectation(
+				name: FontConfiguration.didChangeNotification)
+			expectation.assertForOverFulfill = true
+
+			FontConfiguration.shared.applyFont(
+				NSFont.systemFont(ofSize: FontConfiguration.shared.currentSize))
+
+			wait(for: [expectation], timeout: 1)
+		}
+	}
+
+	func testIncreaseAndDecreaseFontSizeActions() throws {
+		try withSavedFontPreferences {
+			let (doc, editor) = try makeEditor()
+			defer { doc.close() }
+
+			let start = FontConfiguration.shared.currentSize
+			editor.increaseFontSize(self)
+			XCTAssertEqual(FontConfiguration.shared.currentSize, start + 1)
+			XCTAssertEqual(PreferencesManager.shared.fontSize, start + 1)
+
+			editor.decreaseFontSize(self)
+			XCTAssertEqual(FontConfiguration.shared.currentSize, start)
+		}
+	}
+}

--- a/JotTests/FontBroadcastTests.swift
+++ b/JotTests/FontBroadcastTests.swift
@@ -18,24 +18,41 @@ final class FontBroadcastTests: XCTestCase {
 	// wraps itself in this so the developer's real preferences survive;
 	// no stored fixtures — XCTest's setUp is nonisolated under Swift 6
 	// (same reasoning as EditorFormattingTests).
+	//
+	// FontConfiguration.shared is a process-lifetime singleton, so restoring
+	// only the defaults keys would leave the in-memory font mutated for
+	// every later test in the run. currentFont is restored too.
 	private func withSavedFontPreferences(_ body: () throws -> Void) rethrows {
 		let savedFontName = PreferencesManager.shared.fontName
 		let savedFontSize = PreferencesManager.shared.fontSize
-		let savedConfigSize = FontConfiguration.shared.currentSize
+		let savedFont = FontConfiguration.shared.resolvedFont()
 		defer {
-			FontConfiguration.shared.applySize(savedConfigSize)
+			FontConfiguration.shared.applyFont(savedFont)
 			PreferencesManager.shared.fontName = savedFontName
 			PreferencesManager.shared.fontSize = savedFontSize
 		}
+		// Start from a known size: several tests below decrement toward the
+		// floor or assert against the persisted value, and inheriting
+		// whatever the previous test left behind couples them to run order.
+		FontConfiguration.shared.applySize(12)
 		try body()
 	}
 
+	// Closes the document on failure rather than leaving it and its editor
+	// alive as a stray font observer for the rest of the run — the caller's
+	// defer isn't registered until after this returns.
 	private func makeEditor() throws -> (Document, EditorViewController) {
 		let document = Document()
 		document.makeWindowControllers()
-		let editor = try XCTUnwrap(
-			document.windowControllers.first?.contentViewController as? EditorViewController
-		)
+		guard let editor = document.windowControllers.first?.contentViewController
+				as? EditorViewController else {
+			document.close()
+			XCTFail("document window controller should host an EditorViewController")
+			throw XCTSkip("no editor to test")
+		}
+		// viewWillAppear registers the font observer; makeWindowControllers
+		// alone doesn't run it in a headless test
+		editor.viewWillAppear()
 		return (document, editor)
 	}
 
@@ -99,8 +116,12 @@ final class FontBroadcastTests: XCTestCase {
 			let (doc2, editor2) = try makeEditor()
 			defer { doc2.close() }
 
+			// A known non-nil persisted size: asserting against nil would
+			// pass whether or not the zoom wrote to defaults
+			FontConfiguration.shared.applySize(14)
 			let globalSize = FontConfiguration.shared.currentSize
-			let persistedSize = PreferencesManager.shared.fontSize
+			XCTAssertEqual(PreferencesManager.shared.fontSize, 14)
+
 			editor1.increaseFontSize(self)
 
 			XCTAssertEqual(editor1.textView.font?.pointSize, globalSize + 1)
@@ -108,7 +129,52 @@ final class FontBroadcastTests: XCTestCase {
 			// and the persisted preference are all untouched
 			XCTAssertEqual(editor2.textView.font?.pointSize, globalSize)
 			XCTAssertEqual(FontConfiguration.shared.currentSize, globalSize)
-			XCTAssertEqual(PreferencesManager.shared.fontSize, persistedSize)
+			XCTAssertEqual(PreferencesManager.shared.fontSize, 14)
+		}
+	}
+
+	func testActualSizeClearsTheZoom() throws {
+		try withSavedFontPreferences {
+			let (doc, editor) = try makeEditor()
+			defer { doc.close() }
+
+			let globalSize = FontConfiguration.shared.currentSize
+			editor.increaseFontSize(self)
+			editor.increaseFontSize(self)
+			XCTAssertEqual(editor.textView.font?.pointSize, globalSize + 2)
+
+			editor.resetFontSize(self)
+			XCTAssertEqual(editor.textView.font?.pointSize, globalSize)
+		}
+	}
+
+	func testActualSizeIsDisabledWhenNotZoomed() throws {
+		try withSavedFontPreferences {
+			let (doc, editor) = try makeEditor()
+			defer { doc.close() }
+
+			let item = NSMenuItem(
+				title: "Actual Size",
+				action: #selector(EditorViewController.resetFontSize(_:)),
+				keyEquivalent: "0")
+			XCTAssertFalse(editor.validateMenuItem(item),
+						   "Actual Size answers 'is this window zoomed?' — dimmed when it isn't")
+
+			editor.increaseFontSize(self)
+			XCTAssertTrue(editor.validateMenuItem(item))
+
+			editor.resetFontSize(self)
+			XCTAssertFalse(editor.validateMenuItem(item))
+		}
+	}
+
+	func testBiggerCeilingHolds() throws {
+		try withSavedFontPreferences {
+			let (doc, editor) = try makeEditor()
+			defer { doc.close() }
+
+			for _ in 0..<400 { editor.increaseFontSize(self) }
+			XCTAssertEqual(editor.textView.font?.pointSize, 288)
 		}
 	}
 
@@ -119,6 +185,30 @@ final class FontBroadcastTests: XCTestCase {
 
 			for _ in 0..<50 { editor.decreaseFontSize(self) }
 			XCTAssertEqual(editor.textView.font?.pointSize, 6)
+		}
+	}
+
+	func testZoomSurvivesAStateRestorationRoundTrip() throws {
+		try withSavedFontPreferences {
+			let (doc, editor) = try makeEditor()
+			defer { doc.close() }
+
+			editor.increaseFontSize(self)
+			editor.increaseFontSize(self)
+			let zoomedSize = try XCTUnwrap(editor.textView.font?.pointSize)
+
+			let archiver = NSKeyedArchiver(requiringSecureCoding: true)
+			editor.encodeRestorableState(with: archiver)
+			archiver.finishEncoding()
+
+			let (doc2, editor2) = try makeEditor()
+			defer { doc2.close() }
+			let unarchiver = try NSKeyedUnarchiver(forReadingFrom: archiver.encodedData)
+			unarchiver.requiresSecureCoding = true
+			editor2.restoreState(with: unarchiver)
+
+			XCTAssertEqual(editor2.textView.font?.pointSize, zoomedSize,
+						   "a restored window should look like the one that was closed")
 		}
 	}
 

--- a/JotTests/MarkdownProcessorTests.swift
+++ b/JotTests/MarkdownProcessorTests.swift
@@ -735,6 +735,29 @@ final class MarkdownProcessorTests: XCTestCase {
         XCTAssertEqual(textView.string, "")
     }
 
+    // MARK: - Table header stays inside the styling range (#163)
+
+    func testRangedPassOverSeparatorDoesNotBoldHeaderOutsideRange() {
+        textView.string = "| H1 | H2 |\n| --- | --- |"
+        // Style ONLY the separator line; the header line above is outside
+        // the range and its reset pass never ran, so writing bold there
+        // would leave an attribute nothing cleans up.
+        let separatorRange = NSRange(location: 12, length: 13)
+        MarkdownProcessor.applyMarkdownStyling(to: textView, using: font, range: separatorRange)
+
+        // "H" of the header at position 2 must be untouched
+        XCTAssertFalse(hasTrait(textView.textStorage!, location: 2, trait: .boldFontMask))
+    }
+
+    func testFullPassAfterRangedPassStillBoldsHeader() {
+        textView.string = "| H1 | H2 |\n| --- | --- |"
+        let separatorRange = NSRange(location: 12, length: 13)
+        MarkdownProcessor.applyMarkdownStyling(to: textView, using: font, range: separatorRange)
+        MarkdownProcessor.applyMarkdownStyling(to: textView, using: font)
+
+        XCTAssertTrue(hasTrait(textView.textStorage!, location: 2, trait: .boldFontMask))
+    }
+
     // MARK: - Plain text unchanged
 
     func testPlainTextIsLabelColor() {


### PR DESCRIPTION
Phase 2 of the 1.1.0 plan: the small fixes and accessibility cluster, plus the corrections that came out of a three-agent review fan-out.

Closes #163, #116, #153, #152, #124.

(These won't auto-close — this merges to `develop`, not the default branch. Closing manually after merge.)

## What's here

**#163 — table header bolding escaped its styling range.** A ranged pass could write bold attributes outside the range it was given, planting styling that later passes couldn't clean up. Guarded with an intersection check.

**#116 — help window went blank when content was missing.** Now shows a real fallback page with a support link instead of an empty white webview.

**#153 — recovered legacy drafts were anonymous.** They now open with "Recovered Draft" titles and announce themselves to VoiceOver.

**#152 — Show Word Count was a one-way trip.** Now a Show/Hide toggle; a keyboard-only user could previously summon the panel and need the mouse to dismiss it.

**#124 — Settings font changes reached only one window.** The 1:1 delegate is replaced by a broadcast that reaches every open editor and persists with none open. `FontConfiguration.apply(font:size:)` is now the single mutation point — which fixed a real latent bug where choosing a font in the panel silently discarded its point size.

**#124 follow-up — Cmd-+/Cmd-- is now a per-window temporary zoom** rather than a global persisted change, after hands-on testing. Settings stays the global default and the print size; a Settings change resets every window's zoom.

## From the review fan-out

Three agents (code quality, accessibility, macOS conventions) reviewed the branch. All three independently flagged the same top defect.

**`displayName` was permanently wrong after a save.** The override returned the recovery placeholder unconditionally and nothing cleared it, so saving a recovered draft as `chapter-3.txt` left the window title, proxy icon menu, save panel, close alert, Recent Items, and Word Count panel all still reading "Recovered Draft" — for the life of the document. Replaced with NSDocument's own setter, which applies only while untitled and yields to the real filename on save. That also removed a `nonisolated(unsafe)` whose safety argument had been copied from `text` but didn't transfer — `displayName` is callable off the main thread, so the checker was suppressed on the one property that needed it.

The existing test never saved the document, so it only covered the path that worked. The new test was verified to fail against the old override before the fix went in.

**The VoiceOver recovery announcement was inaudible.** Medium priority (coalesced away when VoiceOver is already speaking — and at launch it's busy with the app name and window title), posted during app activation, and targeted at `NSApp` rather than a window. Now waits for `didBecomeActive`, posts at high priority, and targets the recovered window. The title half worked, which is what masked it in sighted testing.

**Font observer lifetime.** A font change arriving between window close and dealloc ran a full styling pass over a text view AppKit was tearing down — the same late-work hazard the timer teardown already guards against. Torn down in `viewWillDisappear`, registered in `viewWillAppear` so a hidden-and-reshown window goes back to following Settings.

**Settings panel observer** registered from only one of three initializers.

**Zoom state carried two meanings in one field**, so nothing could answer "is this window zoomed?". Now an explicit `zoomOverrideSize`.

## New in this branch

**Format > Actual Size (Cmd-0).** Falls out of the zoom refactor. Dimmed unless the window is zoomed, so the menu itself reports the state. Previously the only way back from a zoom was a Settings round-trip — a poor ask of someone who just zoomed down to 6 pt.

**Zoom ceiling at 288 pt**, matching the existing 6 pt floor, and both zoom actions now speak the new size. Cmd-+ is a low-vision accommodation; inferring the result from the screen is the sense it exists to compensate for.

**Editor state restoration.** The app returns `true` from `applicationSupportsSecureRestorableState`, so macOS restores windows on relaunch — but nothing was ever encoded, and a restored window came back in plain-text mode, scrolled to the top, caret at zero. Now encodes mode, zoom, selection, and scroll origin. Restored zoom is clamped to the same limits, since a hand-edited plist shouldn't be able to restore an unreadable window.

## Testing

232 tests pass. New coverage for the save-then-rename case, Actual Size and its menu validation, the zoom ceiling, and a state-restoration round trip.

Test hygiene fixes that came with the review: the font wrapper now restores `FontConfiguration`'s in-memory font (it was leaking a mutated process-lifetime singleton into every later test), starts from a known size, and the per-window assertion no longer compares `nil == nil`.

Hand-tested before this PR.

## Filed, not fixed here

#171 (Cmd-T opens an inert Font panel), #172 (Word Count panel contents unreachable by VoiceOver), #173 (migration can race window restoration), #174 (test `UserDefaults` isolation), #175 (table header clamp), #176 (help page `lang`/`title`/support address).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Ak643B4p59MBpJyiEDsig
