### PR TITLE
feat: 1.1.0 Phase 3 — line number gutter (#42, #101–#109, #178)

### DIFF
--- a/Jot/App/AppDelegate.swift
+++ b/Jot/App/AppDelegate.swift
@@ -72,6 +72,15 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
 		}
 	}
 	
+	/// View > Show/Hide Line Numbers. Lives here rather than on the editor
+	/// because it only writes the shared preference — every open editor
+	/// observes that and updates itself (#106), and the command stays
+	/// meaningful with no document window open. Same Show/Hide title
+	/// pattern as Word Count (#152), handled in validateMenuItem.
+	@IBAction func toggleLineNumbers(_ sender: Any) {
+		PreferencesManager.shared.showLineNumbers.toggle()
+	}
+
 	@IBAction func openHelpWebsite(_ sender: Any) {
 		if let url = URL(string: "https://github.com/brianjgoodwin/Jot/wiki/Feedback-and-Support") {
 			NSWorkspace.shared.open(url)
@@ -97,6 +106,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
 			menuItem.title = (wordCountPanelController?.window?.isVisible == true)
 				? "Hide Word Count"
 				: "Show Word Count"
+		}
+		if menuItem.action == #selector(toggleLineNumbers(_:)) {
+			menuItem.title = PreferencesManager.shared.showLineNumbers
+				? "Hide Line Numbers"
+				: "Show Line Numbers"
 		}
 		return true
 	}

--- a/Jot/Editor/EditorTextView.swift
+++ b/Jot/Editor/EditorTextView.swift
@@ -2,6 +2,8 @@
 //  EditorTextView.swift
 //  Jot
 //
+//  Created on 8/8/26.
+//
 //  NSTextView subclass that intercepts file drops and opens them
 //  as documents instead of inserting the file path as text.
 //

--- a/Jot/Editor/EditorViewController.swift
+++ b/Jot/Editor/EditorViewController.swift
@@ -689,13 +689,14 @@ class EditorViewController: NSViewController, NSTextViewDelegate {
 				textView.textContainer?.widthTracksTextView = false
 				textView.textContainer?.containerSize = CGSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
 				scrollView.hasHorizontalScroller = true
-				// Update the text view's frame width to be wider than the scroll view's content size width
+				scrollView.horizontalScrollElasticity = .automatic
 				textView.setFrameSize(CGSize(width: scrollView.frame.width * 2, height: textView.frame.height))
 			} else {
 				// Enable word wrapping
 				textView.textContainer?.widthTracksTextView = true
 				textView.textContainer?.containerSize = CGSize(width: scrollView.contentSize.width, height: CGFloat.greatestFiniteMagnitude)
 				scrollView.hasHorizontalScroller = false
+				scrollView.horizontalScrollElasticity = .none
 				textView.setFrameSize(CGSize(width: scrollView.contentSize.width, height: textView.frame.height))
 			}
 		}

--- a/Jot/Editor/EditorViewController.swift
+++ b/Jot/Editor/EditorViewController.swift
@@ -262,16 +262,18 @@ class EditorViewController: NSViewController, NSTextViewDelegate {
 
 	private func installGutter() {
 		guard lineNumberGutter == nil,
-			  let scrollView = textView.enclosingScrollView else { return }
+			  let scrollView = textView.enclosingScrollView as? GutterScrollView else { return }
 		let gutter = LineNumberGutterView(scrollView: scrollView, textView: textView)
-		scrollView.verticalRulerView = gutter
-		scrollView.hasVerticalRuler = true
-		scrollView.rulersVisible = true
+		// A plain subview, deliberately NOT verticalRulerView: the ruler
+		// API makes the clip view report a phantom leftward scroll range
+		// that rubber-bands (#178). See the geometry note in
+		// LineNumberGutter.swift before "improving" this.
+		scrollView.addSubview(gutter)
+		scrollView.gutterView = gutter
 		lineNumberGutter = gutter
 		// Geometry is owned by GutterScrollView.tile(), which reserves the
-		// ruler's strip by shrinking the clip view — this just installs
-		// the ruler and asks for a retile. See the geometry note in
-		// LineNumberGutter.swift before "improving" this.
+		// gutter's strip by shrinking the clip view — this just installs
+		// the strip and asks for a retile.
 		scrollView.tile()
 	}
 
@@ -283,12 +285,11 @@ class EditorViewController: NSViewController, NSTextViewDelegate {
 		// would leave the delegate dangling exactly when the view
 		// hierarchy is being torn apart (#178).
 		gutter.tearDown()
+		gutter.removeFromSuperview()
 		lineNumberGutter = nil
 
-		guard let scrollView = textView.enclosingScrollView else { return }
-		scrollView.rulersVisible = false
-		scrollView.hasVerticalRuler = false
-		scrollView.verticalRulerView = nil
+		guard let scrollView = textView.enclosingScrollView as? GutterScrollView else { return }
+		scrollView.gutterView = nil
 		scrollView.tile()
 	}
 	

--- a/Jot/Editor/EditorViewController.swift
+++ b/Jot/Editor/EditorViewController.swift
@@ -276,13 +276,19 @@ class EditorViewController: NSViewController, NSTextViewDelegate {
 	}
 
 	private func removeGutter() {
-		guard let gutter = lineNumberGutter,
-			  let scrollView = textView.enclosingScrollView else { return }
+		guard let gutter = lineNumberGutter else { return }
+		// Teardown is unconditional: it clears the assign (not weak)
+		// text storage delegate, and must run even if the text view has
+		// been detached from its scroll view — gating it on geometry
+		// would leave the delegate dangling exactly when the view
+		// hierarchy is being torn apart (#178).
 		gutter.tearDown()
+		lineNumberGutter = nil
+
+		guard let scrollView = textView.enclosingScrollView else { return }
 		scrollView.rulersVisible = false
 		scrollView.hasVerticalRuler = false
 		scrollView.verticalRulerView = nil
-		lineNumberGutter = nil
 		scrollView.tile()
 	}
 	

--- a/Jot/Editor/EditorViewController.swift
+++ b/Jot/Editor/EditorViewController.swift
@@ -268,9 +268,10 @@ class EditorViewController: NSViewController, NSTextViewDelegate {
 		scrollView.hasVerticalRuler = true
 		scrollView.rulersVisible = true
 		lineNumberGutter = gutter
-		// AppKit overlays the ruler and shifts the content beside it on
-		// its own — no clip shrinking, no inset fiddling. See the
-		// geometry note in LineNumberGutter.swift before "improving" this.
+		// Geometry is owned by GutterScrollView.tile(), which reserves the
+		// ruler's strip by shrinking the clip view — this just installs
+		// the ruler and asks for a retile. See the geometry note in
+		// LineNumberGutter.swift before "improving" this.
 		scrollView.tile()
 	}
 

--- a/Jot/Editor/EditorViewController.swift
+++ b/Jot/Editor/EditorViewController.swift
@@ -33,6 +33,10 @@ class EditorViewController: NSViewController, NSTextViewDelegate {
 	/// global Settings size. Kept separate from selectedFontSize so "is this
 	/// window zoomed?" is answerable — which is what Actual Size needs.
 	private var zoomOverrideSize: CGFloat?
+
+	/// Non-nil exactly while the gutter is installed on the scroll view.
+	/// Whether it should be installed is the preference's call alone (#106).
+	private var lineNumberGutter: LineNumberGutterView?
 	
 	override func viewDidLoad() {
 		super.viewDidLoad()
@@ -71,6 +75,19 @@ class EditorViewController: NSViewController, NSTextViewDelegate {
 			name: FontConfiguration.didChangeNotification,
 			object: FontConfiguration.shared
 		)
+
+		// Same lifecycle as the font observer, same reason. The reconcile
+		// call also covers a preference change that happened while this
+		// window was hidden and not observing.
+		NotificationCenter.default.removeObserver(
+			self, name: PreferencesManager.showLineNumbersDidChangeNotification, object: nil)
+		NotificationCenter.default.addObserver(
+			self,
+			selector: #selector(showLineNumbersDidChange),
+			name: PreferencesManager.showLineNumbersDidChangeNotification,
+			object: nil
+		)
+		updateGutterVisibility()
 	}
 
 	@objc private func fontConfigurationDidChange(_ notification: Notification) {
@@ -88,6 +105,9 @@ class EditorViewController: NSViewController, NSTextViewDelegate {
 		if currentMode == .markdown {
 			applyStyling()
 		}
+		// The gutter's number size tracks the editor font
+		lineNumberGutter?.updateThickness()
+		lineNumberGutter?.needsDisplay = true
 	}
 
 	override func viewWillDisappear() {
@@ -108,6 +128,13 @@ class EditorViewController: NSViewController, NSTextViewDelegate {
 		// view AppKit is tearing down.
 		NotificationCenter.default.removeObserver(
 			self, name: FontConfiguration.didChangeNotification, object: nil)
+		NotificationCenter.default.removeObserver(
+			self, name: PreferencesManager.showLineNumbersDidChangeNotification, object: nil)
+
+		// NSTextStorage.delegate is assign, not weak: detach the gutter
+		// while everything is still alive rather than trusting teardown
+		// order. viewWillAppear reinstalls it on a reshow.
+		removeGutter()
 	}
 
 	deinit {
@@ -211,7 +238,51 @@ class EditorViewController: NSViewController, NSTextViewDelegate {
 		if currentMode == .markdown {
 			applyStyling()
 		}
+		lineNumberGutter?.updateThickness()
+		lineNumberGutter?.needsDisplay = true
 		invalidateRestorableState()
+	}
+
+	// MARK: - Line numbers (#42)
+
+	@objc private func showLineNumbersDidChange(_ notification: Notification) {
+		updateGutterVisibility()
+	}
+
+	/// Reconcile this window with the preference — the only state the
+	/// gutter has (#106). Idempotent, so calling it on appearance and on
+	/// every change notification is safe.
+	private func updateGutterVisibility() {
+		if PreferencesManager.shared.showLineNumbers {
+			installGutter()
+		} else {
+			removeGutter()
+		}
+	}
+
+	private func installGutter() {
+		guard lineNumberGutter == nil,
+			  let scrollView = textView.enclosingScrollView else { return }
+		let gutter = LineNumberGutterView(scrollView: scrollView, textView: textView)
+		scrollView.verticalRulerView = gutter
+		scrollView.hasVerticalRuler = true
+		scrollView.rulersVisible = true
+		lineNumberGutter = gutter
+		// AppKit overlays the ruler and shifts the content beside it on
+		// its own — no clip shrinking, no inset fiddling. See the
+		// geometry note in LineNumberGutter.swift before "improving" this.
+		scrollView.tile()
+	}
+
+	private func removeGutter() {
+		guard let gutter = lineNumberGutter,
+			  let scrollView = textView.enclosingScrollView else { return }
+		gutter.tearDown()
+		scrollView.rulersVisible = false
+		scrollView.hasVerticalRuler = false
+		scrollView.verticalRulerView = nil
+		lineNumberGutter = nil
+		scrollView.tile()
 	}
 	
 	// MARK: - State restoration

--- a/Jot/Editor/FontConfiguration.swift
+++ b/Jot/Editor/FontConfiguration.swift
@@ -2,6 +2,8 @@
 //  FontConfiguration.swift
 //  Jot
 //
+//  Created on 8/9/26.
+//
 //  Shared font loading, saving, and application logic used by
 //  EditorViewController and SettingsPanelController.
 //

--- a/Jot/Editor/LineNumberGutter.swift
+++ b/Jot/Editor/LineNumberGutter.swift
@@ -640,10 +640,11 @@ final class LineNumberGutterView: NSRulerView {
 
 // MARK: - Layout manager delegate
 
-// @preconcurrency for the same reason as NSTextStorageDelegate below:
-// layout for an NSTextView happens on the main thread; the conformance
-// asserts that at runtime.
-extension LineNumberGutterView: @preconcurrency NSLayoutManagerDelegate {
+// The conformance is isolated to the main actor (SE-0470): layout for an
+// NSTextView happens on the main thread, and an isolated conformance
+// states that statically instead of asserting it at runtime the way the
+// previous @preconcurrency conformance did.
+extension LineNumberGutterView: @MainActor NSLayoutManagerDelegate {
     // The one callback this delegate exists for: a restored window can
     // draw before layout reaches the restored scroll position, and the
     // glyph query in lineNumberPositions comes back empty. Each layout
@@ -658,11 +659,9 @@ extension LineNumberGutterView: @preconcurrency NSLayoutManagerDelegate {
 
 // MARK: - Text storage delegate
 
-// @preconcurrency: the delegate protocol is nonisolated, but every edit to
-// an NSTextView's storage happens on the main thread; the conformance
-// asserts that at runtime instead of infecting the class with nonisolated
-// members.
-extension LineNumberGutterView: @preconcurrency NSTextStorageDelegate {
+// Isolated conformance for the same reason as NSLayoutManagerDelegate
+// above: every edit to an NSTextView's storage happens on the main thread.
+extension LineNumberGutterView: @MainActor NSTextStorageDelegate {
     func textStorage(_ textStorage: NSTextStorage,
                      didProcessEditing editedMask: NSTextStorageEditActions,
                      range editedRange: NSRange,

--- a/Jot/Editor/LineNumberGutter.swift
+++ b/Jot/Editor/LineNumberGutter.swift
@@ -250,6 +250,10 @@ struct LineIndex {
     /// length change. The rescan region is widened to whole lines so that a
     /// CRLF pair formed or split at an edit boundary is re-read as a unit —
     /// the case a character-range rescan gets wrong.
+    ///
+    /// The update mutates `lineStarts` in place: the kept prefix is never
+    /// copied, and the typical typing edit replaces a same-sized middle
+    /// slice, so the array is not reallocated per keystroke.
     mutating func applyEdit(in string: NSString, editedRange: NSRange, changeInLength delta: Int) {
         let length = string.length
         let editStart = min(editedRange.location, length)
@@ -259,25 +263,27 @@ struct LineIndex {
         let rescanStart = string.lineRange(for: NSRange(location: editStart, length: 0)).location
         let rescanEnd = NSMaxRange(string.lineRange(for: NSRange(location: editEnd, length: 0)))
 
-        // Starts strictly before the rescanned region: their terminators
-        // are in untouched text, so they are still valid as-is.
-        var updated = Array(lineStarts.prefix(while: { $0 < rescanStart }))
-
-        // rescanStart is a line start in the new string by construction
-        // (it came from lineRange), and it is not in the kept prefix.
-        updated.append(rescanStart)
-        updated.append(contentsOf: starts(in: string, from: rescanStart, upTo: rescanEnd))
+        // Starts strictly before the rescanned region keep their values:
+        // their terminators are in untouched text. firstIndex is an upper
+        // bound, so "greater than rescanStart - 1" means ">= rescanStart".
+        let keptCount = firstIndex(in: lineStarts, greaterThan: rescanStart - 1)
 
         // Starts strictly after the rescanned region existed before the
         // edit at (position - delta), and their terminators are in
-        // untouched text — shift them instead of re-reading them.
+        // untouched text — shift them in place instead of re-reading them.
         let oldBoundary = rescanEnd - delta
         let firstShifted = firstIndex(in: lineStarts, greaterThan: oldBoundary)
-        for i in firstShifted..<lineStarts.count {
-            updated.append(lineStarts[i] + delta)
+        if delta != 0 {
+            for i in firstShifted..<lineStarts.count {
+                lineStarts[i] += delta
+            }
         }
 
-        lineStarts = updated
+        // rescanStart is a line start in the new string by construction
+        // (it came from lineRange), and it is not in the kept prefix.
+        var rescanned = [rescanStart]
+        rescanned.append(contentsOf: starts(in: string, from: rescanStart, upTo: rescanEnd))
+        lineStarts.replaceSubrange(keptCount..<firstShifted, with: rescanned)
     }
 
     /// 1-based line number of the line containing `location`. A location at
@@ -345,6 +351,12 @@ final class LineNumberGutterView: NSRulerView {
     private weak var textView: NSTextView?
     private var lineIndex = LineIndex()
 
+    /// The caret's line as of the last selection change, so caret moves
+    /// within one line — the overwhelmingly common selection change —
+    /// skip the repaint: nothing the gutter draws depends on the caret
+    /// beyond which number is bold.
+    private var currentLine = 1
+
     private static let horizontalPadding: CGFloat = 5
     private static let minimumThickness: CGFloat = 32
 
@@ -361,6 +373,7 @@ final class LineNumberGutterView: NSRulerView {
         clipsToBounds = true
 
         lineIndex.rebuild(from: textView.string as NSString)
+        currentLine = lineIndex.lineNumber(forCharacterAt: textView.selectedRange().location)
         updateThickness()
 
         // The gutter owns the text storage delegate slot; nothing else in
@@ -443,7 +456,24 @@ final class LineNumberGutterView: NSRulerView {
     override var isFlipped: Bool { true }
 
     @objc private func selectionDidChange(_ notification: Notification) {
-        needsDisplay = true
+        if noteSelectionChanged() {
+            needsDisplay = true
+        }
+    }
+
+    /// Whether the latest selection change moved the caret to another
+    /// line — the only selection change the gutter draws differently
+    /// (the bold number). Internal so tests can pin the skip without
+    /// going through needsDisplay, whose readback is unreliable in a
+    /// headless window.
+    func noteSelectionChanged() -> Bool {
+        guard let textView = textView else { return false }
+        let line = lineIndex.lineNumber(forCharacterAt: textView.selectedRange().location)
+        if line == currentLine {
+            return false
+        }
+        currentLine = line
+        return true
     }
 
     @objc private func scrollViewDidScroll(_ notification: Notification) {
@@ -580,13 +610,20 @@ final class LineNumberGutterView: NSRulerView {
 
         guard let textView = textView else { return }
 
-        let currentLine = lineIndex.lineNumber(forCharacterAt: textView.selectedRange().location)
+        // Recomputed at paint time rather than trusting the cached
+        // currentLine — draw is the source of truth for what's bold.
+        let caretLine = lineIndex.lineNumber(forCharacterAt: textView.selectedRange().location)
+        let regularAttributes: [NSAttributedString.Key: Any] = [
+            .font: numberFont(bold: false),
+            .foregroundColor: NSColor.secondaryLabelColor,
+        ]
+        let boldAttributes: [NSAttributedString.Key: Any] = [
+            .font: numberFont(bold: true),
+            .foregroundColor: NSColor.secondaryLabelColor,
+        ]
 
         for position in lineNumberPositions(in: textView.visibleRect) {
-            let attributes: [NSAttributedString.Key: Any] = [
-                .font: numberFont(bold: position.number == currentLine),
-                .foregroundColor: NSColor.secondaryLabelColor,
-            ]
+            let attributes = position.number == caretLine ? boldAttributes : regularAttributes
             let numberString = String(position.number) as NSString
             let size = numberString.size(withAttributes: attributes)
             let y = convert(NSPoint(x: 0, y: position.yInTextView), from: textView).y

--- a/Jot/Editor/LineNumberGutter.swift
+++ b/Jot/Editor/LineNumberGutter.swift
@@ -561,7 +561,9 @@ final class LineNumberGutterView: NSRulerView {
 
     /// Width needed to show `lineCount`'s digits in `font`, padded. Pure so
     /// the digit-boundary behavior (9 → 10, 99 → 100) is directly testable.
-    static func requiredThickness(forLineCount lineCount: Int, font: NSFont) -> CGFloat {
+    /// Named to stay clear of NSRulerView's `requiredThickness` property,
+    /// which tile() reads for the live strip width.
+    static func thickness(forLineCount lineCount: Int, font: NSFont) -> CGFloat {
         let digits = max(String(lineCount).count, 2)
         let sample = String(repeating: "8", count: digits) as NSString
         let width = sample.size(withAttributes: [.font: font]).width
@@ -572,7 +574,7 @@ final class LineNumberGutterView: NSRulerView {
     /// changes and on font changes — not per draw, and never as a function
     /// of a full-document line scan (#103).
     func updateThickness() {
-        let needed = Self.requiredThickness(
+        let needed = Self.thickness(
             forLineCount: lineIndex.lineCount,
             font: numberFont(bold: false)
         )

--- a/Jot/Editor/LineNumberGutter.swift
+++ b/Jot/Editor/LineNumberGutter.swift
@@ -1,0 +1,473 @@
+//
+//  LineNumberGutter.swift
+//  Jot
+//
+//  Line number gutter for the editor (#42), rebuilt on NSRulerView.
+//
+//  The first attempt (feature/42-line-number-gutter) drew numbers in the
+//  text view's background behind a textContainerOrigin offset, which meant
+//  hand-synchronizing the container width with the inset on every toggle,
+//  resize, and wrap change — and it got that wrong in ways that clipped
+//  text (#104). Here the geometry lives in exactly one place —
+//  GutterScrollView.tile() below — and everything else follows from the
+//  clip view's frame, which the text system already tracks. Invalidating
+//  the gutter also no longer redraws the text (#103).
+//
+
+import Cocoa
+
+// MARK: - Scroll view geometry
+//
+// Current macOS treats vertical rulers as an overlay and applies its own
+// accommodation — but lazily and only partially in this configuration:
+// nothing happens until the first live resize (ruler overlaps the text at
+// launch), and after one it shifts the content's rest position without
+// narrowing the tracked text width (right edge wraps out of view). All of
+// this was established empirically with on-screen windows; none of it is
+// something to rely on. So both halves of the geometry are owned here,
+// deterministically: GutterScrollView.tile() reserves the ruler's strip by
+// shrinking the clip view — the arrangement widthTracksTextView already
+// understands, so wrap width follows for free (#104) — and GutterClipView
+// refuses the OS's overlay rest-position shift, which would otherwise open
+// a dead gutter-width gap between the numbers and the text.
+
+/// The editor's scroll view (set as a custom class in the storyboard).
+final class GutterScrollView: NSScrollView {
+
+    // During a live drag AppKit defers tiling to the end of the resize.
+    // Without the gutter that didn't matter — the clip tracked the frame
+    // and text reflowed continuously. With the clip's placement owned by
+    // tile(), deferred tiling means text that only reflows on mouse-up.
+    // Retiling here restores the continuous reflow; tile() is idempotent
+    // and cheap, so the redundant calls outside live resize are fine.
+    override func setFrameSize(_ newSize: NSSize) {
+        super.setFrameSize(newSize)
+        if rulersVisible {
+            tile()
+        }
+    }
+
+    override func tile() {
+        super.tile()
+        guard rulersVisible, let ruler = verticalRulerView else { return }
+
+        let clipFrame = contentView.frame
+        let inset = min(ruler.requiredThickness, clipFrame.maxX)
+
+        // If a future macOS reserves ruler space in tile() again, the
+        // clip arrives already offset — normalize the ruler beside it
+        // and don't shrink a second time.
+        if clipFrame.minX >= inset {
+            ruler.frame = NSRect(x: clipFrame.minX - inset, y: clipFrame.minY,
+                                 width: inset, height: clipFrame.height)
+            return
+        }
+
+        ruler.frame = NSRect(x: 0, y: clipFrame.minY,
+                             width: inset, height: clipFrame.height)
+        contentView.frame = NSRect(x: inset, y: clipFrame.minY,
+                                   width: clipFrame.maxX - inset,
+                                   height: clipFrame.height)
+    }
+}
+
+/// The editor's clip view (set as a custom class in the storyboard).
+final class GutterClipView: NSClipView {
+
+    override func constrainBoundsRect(_ proposedBounds: NSRect) -> NSRect {
+        var bounds = super.constrainBoundsRect(proposedBounds)
+        // The OS proposes a rest position one ruler-width into negative x
+        // to slide content out from under an overlay ruler. tile() above
+        // already moved the clip itself, so accepting the shift too would
+        // indent the text a second gutter-width.
+        if let scrollView = enclosingScrollView, scrollView.rulersVisible {
+            bounds.origin.x = max(bounds.origin.x, 0)
+        }
+        return bounds
+    }
+}
+
+// MARK: - LineIndex
+
+/// Sorted character offsets of every line start in a string, kept current
+/// across edits. This exists so the gutter can answer "what line number is
+/// this character on?" with a binary search instead of scanning the
+/// document from character zero on every draw — the scan made gutter cost
+/// O(document) per frame and miscounted by one when the viewport started
+/// mid wrapped line (#102, #103).
+///
+/// Model: line 1 starts at offset 0; a new line starts after every line
+/// terminator, including one at the very end of the string. So "a\n" has
+/// starts [0, 2] — the trailing empty line is a real line (it is where the
+/// caret sits after Return, and the gutter must number it, #105) — and the
+/// empty string has starts [0]: one line.
+struct LineIndex {
+
+    private(set) var lineStarts: [Int] = [0]
+
+    var lineCount: Int { lineStarts.count }
+
+    init() {}
+
+    init(string: NSString) {
+        rebuild(from: string)
+    }
+
+    mutating func rebuild(from string: NSString) {
+        lineStarts = [0]
+        lineStarts.append(contentsOf: starts(in: string, from: 0, upTo: string.length))
+    }
+
+    /// Update the index for one edit, touching only the affected lines.
+    /// `editedRange` and `delta` are exactly what
+    /// `NSTextStorageDelegate.textStorage(_:didProcessEditing:...)` provides:
+    /// the range in the post-edit string and the length change.
+    ///
+    /// The shape: keep starts before the edited line untouched, rescan just
+    /// the lines the edit could have altered, and shift the rest by the
+    /// length change. The rescan region is widened to whole lines so that a
+    /// CRLF pair formed or split at an edit boundary is re-read as a unit —
+    /// the case a character-range rescan gets wrong.
+    mutating func applyEdit(in string: NSString, editedRange: NSRange, changeInLength delta: Int) {
+        let length = string.length
+        let editStart = min(editedRange.location, length)
+        let editEnd = min(NSMaxRange(editedRange), length)
+
+        // Whole-line bounds of the edit, in the new string.
+        let rescanStart = string.lineRange(for: NSRange(location: editStart, length: 0)).location
+        let rescanEnd = NSMaxRange(string.lineRange(for: NSRange(location: editEnd, length: 0)))
+
+        // Starts strictly before the rescanned region: their terminators
+        // are in untouched text, so they are still valid as-is.
+        var updated = Array(lineStarts.prefix(while: { $0 < rescanStart }))
+
+        // rescanStart is a line start in the new string by construction
+        // (it came from lineRange), and it is not in the kept prefix.
+        updated.append(rescanStart)
+        updated.append(contentsOf: starts(in: string, from: rescanStart, upTo: rescanEnd))
+
+        // Starts strictly after the rescanned region existed before the
+        // edit at (position - delta), and their terminators are in
+        // untouched text — shift them instead of re-reading them.
+        let oldBoundary = rescanEnd - delta
+        let firstShifted = firstIndex(in: lineStarts, greaterThan: oldBoundary)
+        for i in firstShifted..<lineStarts.count {
+            updated.append(lineStarts[i] + delta)
+        }
+
+        lineStarts = updated
+    }
+
+    /// 1-based line number of the line containing `location`. A location at
+    /// the very end of a terminator-final string lands on the trailing
+    /// empty line, which is what the caret does too.
+    func lineNumber(forCharacterAt location: Int) -> Int {
+        return firstIndex(in: lineStarts, greaterThan: location)
+    }
+
+    func isLineStart(_ location: Int) -> Bool {
+        let index = firstIndex(in: lineStarts, greaterThan: location)
+        return index > 0 && lineStarts[index - 1] == location
+    }
+
+    /// Line starts after each terminated line in [from, upTo), where `from`
+    /// must itself be a line start. A terminator ending exactly at `upTo`
+    /// contributes a start there — that is the trailing empty line when
+    /// `upTo` is the string length.
+    private func starts(in string: NSString, from: Int, upTo limit: Int) -> [Int] {
+        var found: [Int] = []
+        var index = from
+        while index < limit {
+            var lineEnd = 0
+            var contentsEnd = 0
+            string.getLineStart(nil, end: &lineEnd, contentsEnd: &contentsEnd,
+                                for: NSRange(location: index, length: 0))
+            // contentsEnd != lineEnd means the line ended with a terminator,
+            // so a new line starts at lineEnd.
+            if contentsEnd != lineEnd {
+                found.append(lineEnd)
+            }
+            index = lineEnd
+        }
+        return found
+    }
+
+    /// Index of the first element greater than `value` (upper bound).
+    /// `sorted` must be ascending.
+    private func firstIndex(in sorted: [Int], greaterThan value: Int) -> Int {
+        var low = 0
+        var high = sorted.count
+        while low < high {
+            let mid = (low + high) / 2
+            if sorted[mid] <= value {
+                low = mid + 1
+            } else {
+                high = mid
+            }
+        }
+        return low
+    }
+}
+
+// MARK: - LineNumberGutterView
+
+/// The vertical ruler that draws line numbers beside the editor.
+///
+/// Aesthetics carried over from the first gutter branch: monospaced-digit
+/// numbers one point smaller than the editor font, bold on the caret's
+/// line, right-aligned against a hairline separator. Colors are semantic
+/// (#107) — the hardcoded appearance-branching grays regressed the #49
+/// semantic-color work and ignored the Increase Contrast variants.
+final class LineNumberGutterView: NSRulerView {
+
+    private weak var textView: NSTextView?
+    private var lineIndex = LineIndex()
+
+    private static let horizontalPadding: CGFloat = 5
+    private static let minimumThickness: CGFloat = 32
+
+    init(scrollView: NSScrollView, textView: NSTextView) {
+        self.textView = textView
+        super.init(scrollView: scrollView, orientation: .verticalRuler)
+        clientView = textView
+
+        // Since macOS 14, views do NOT clip their drawing to their bounds
+        // by default, and the dirtyRect handed to draw(_:) can span far
+        // beyond this view. Without this, the background fill below paints
+        // controlBackgroundColor across the entire window — over the text
+        // — which renders every document apparently empty.
+        clipsToBounds = true
+
+        lineIndex.rebuild(from: textView.string as NSString)
+        updateThickness()
+
+        // The gutter owns the text storage delegate slot; nothing else in
+        // the app uses it. If that ever changes, the edits must be fanned
+        // out, or the index here goes silently stale.
+        textView.textStorage?.delegate = self
+
+        // Only the gutter redraws on caret movement — invalidating the
+        // whole text view for a bold number forced a full glyph redraw per
+        // keystroke on the old branch (#103).
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(selectionDidChange),
+            name: NSTextView.didChangeSelectionNotification,
+            object: textView
+        )
+        // Belt and suspenders for scroll sync: ruler views normally track
+        // their scroll view, but layer-backed scroll views have a history
+        // of leaving rulers a frame behind. The clip view already posts
+        // bounds changes for the styling debounce.
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(scrollViewDidScroll),
+            name: NSView.boundsDidChangeNotification,
+            object: scrollView.contentView
+        )
+    }
+
+    required init(coder: NSCoder) {
+        fatalError("LineNumberGutterView is created in code")
+    }
+
+    /// Called by the editor before the gutter is removed from its scroll
+    /// view, so a text edit arriving afterward doesn't message a ruler
+    /// that is mid-teardown.
+    func tearDown() {
+        textView?.textStorage?.delegate = nil
+        NotificationCenter.default.removeObserver(self)
+    }
+
+    deinit {
+        // Backstop for paths that skip tearDown. Matches the pattern in
+        // EditorViewController and WordCountPanelController.
+        NotificationCenter.default.removeObserver(self)
+    }
+
+    // The text view is flipped; declaring the gutter flipped too keeps
+    // every converted y coordinate in the same top-down space.
+    override var isFlipped: Bool { true }
+
+    @objc private func selectionDidChange(_ notification: Notification) {
+        needsDisplay = true
+    }
+
+    @objc private func scrollViewDidScroll(_ notification: Notification) {
+        needsDisplay = true
+    }
+
+    // MARK: Geometry
+
+    /// Everything the gutter will draw for `visibleRect` (text view
+    /// coordinates): one entry per line whose first fragment is visible,
+    /// plus the trailing empty line when its fragment is. Separated from
+    /// draw(_:) so tests can drive it with arbitrary rects — including the
+    /// mid-wrapped-line viewport that broke the old prefix counter (#102).
+    struct LinePosition: Equatable {
+        /// Top of the line's first fragment, text view coordinates.
+        var yInTextView: CGFloat
+        var height: CGFloat
+        var number: Int
+    }
+
+    func lineNumberPositions(in visibleRect: NSRect) -> [LinePosition] {
+        guard let textView = textView,
+              let layoutManager = textView.layoutManager,
+              let textContainer = textView.textContainer else { return [] }
+
+        let containerOrigin = textView.textContainerOrigin
+        var rectInContainer = visibleRect
+        rectInContainer.origin.x -= containerOrigin.x
+        rectInContainer.origin.y -= containerOrigin.y
+
+        // Empty documents lay out nothing, so nothing forces the extra
+        // line fragment (the caret's line) into existence. Ensuring layout
+        // here is O(1) — there is no text.
+        if (textView.string as NSString).length == 0 {
+            layoutManager.ensureLayout(for: textContainer)
+        }
+
+        var positions: [LinePosition] = []
+
+        let glyphRange = layoutManager.glyphRange(forBoundingRect: rectInContainer, in: textContainer)
+        var glyphIndex = glyphRange.location
+        while glyphIndex < NSMaxRange(glyphRange) {
+            var fragmentGlyphRange = NSRange(location: NSNotFound, length: 0)
+            let fragmentRect = layoutManager.lineFragmentRect(
+                forGlyphAt: glyphIndex,
+                effectiveRange: &fragmentGlyphRange
+            )
+            let characterIndex = layoutManager.characterIndexForGlyph(at: glyphIndex)
+
+            // Continuation fragments of a soft-wrapped line don't start a
+            // line, so they get no number — and no counter to misplace: the
+            // number is looked up from the index, not accumulated (#102).
+            if lineIndex.isLineStart(characterIndex) {
+                positions.append(LinePosition(
+                    yInTextView: fragmentRect.minY + containerOrigin.y,
+                    height: fragmentRect.height,
+                    number: lineIndex.lineNumber(forCharacterAt: characterIndex)
+                ))
+            }
+
+            let nextGlyphIndex = NSMaxRange(fragmentGlyphRange)
+            if nextGlyphIndex <= glyphIndex { break }
+            glyphIndex = nextGlyphIndex
+        }
+
+        // The line after a trailing newline — and the only line of an empty
+        // document — has no glyphs, only the extra line fragment. Every
+        // standard gutter numbers it; leaving it blank while the caret
+        // sits there reads as a glitch (#105).
+        if layoutManager.extraLineFragmentTextContainer != nil {
+            let extraRect = layoutManager.extraLineFragmentRect
+            if extraRect.intersects(rectInContainer) || (textView.string as NSString).length == 0 {
+                positions.append(LinePosition(
+                    yInTextView: extraRect.minY + containerOrigin.y,
+                    height: extraRect.height,
+                    number: lineIndex.lineCount
+                ))
+            }
+        }
+
+        return positions
+    }
+
+    // MARK: Width
+
+    /// Width needed to show `lineCount`'s digits in `font`, padded. Pure so
+    /// the digit-boundary behavior (9 → 10, 99 → 100) is directly testable.
+    static func requiredThickness(forLineCount lineCount: Int, font: NSFont) -> CGFloat {
+        let digits = max(String(lineCount).count, 2)
+        let sample = String(repeating: "8", count: digits) as NSString
+        let width = sample.size(withAttributes: [.font: font]).width
+        return max(ceil(width) + horizontalPadding * 2, minimumThickness)
+    }
+
+    /// Re-derives the ruler width. Called when the digit count of the total
+    /// changes and on font changes — not per draw, and never as a function
+    /// of a full-document line scan (#103).
+    func updateThickness() {
+        let needed = Self.requiredThickness(
+            forLineCount: lineIndex.lineCount,
+            font: numberFont(bold: false)
+        )
+        if abs(needed - ruleThickness) > 0.5 {
+            ruleThickness = needed
+            // GutterScrollView.tile() is what actually moves the clip view
+            // for the new width; a thickness change must not wait for the
+            // next resize to take effect
+            scrollView?.tile()
+        }
+    }
+
+    private func numberFont(bold: Bool) -> NSFont {
+        let editorSize = textView?.font?.pointSize ?? NSFont.systemFontSize
+        let size = max(editorSize - 1, 9)
+        return .monospacedDigitSystemFont(ofSize: size, weight: bold ? .bold : .regular)
+    }
+
+    // MARK: Drawing
+
+    // The gutter owns its entire surface — no markers, no hash marks — so
+    // draw(_:) replaces NSRulerView's default drawing outright instead of
+    // hooking drawHashMarksAndLabels(in:).
+    override func draw(_ dirtyRect: NSRect) {
+        // Belt and suspenders with clipsToBounds: never paint outside the
+        // gutter even if the clipping arrangement changes again
+        let gutterRect = bounds.intersection(dirtyRect)
+        guard !gutterRect.isNull else { return }
+
+        NSColor.controlBackgroundColor.setFill()
+        gutterRect.fill()
+
+        NSColor.separatorColor.setFill()
+        NSRect(x: bounds.maxX - 1, y: gutterRect.minY, width: 1, height: gutterRect.height).fill()
+
+        guard let textView = textView else { return }
+
+        let currentLine = lineIndex.lineNumber(forCharacterAt: textView.selectedRange().location)
+
+        for position in lineNumberPositions(in: textView.visibleRect) {
+            let attributes: [NSAttributedString.Key: Any] = [
+                .font: numberFont(bold: position.number == currentLine),
+                .foregroundColor: NSColor.secondaryLabelColor,
+            ]
+            let numberString = String(position.number) as NSString
+            let size = numberString.size(withAttributes: attributes)
+            let y = convert(NSPoint(x: 0, y: position.yInTextView), from: textView).y
+            let drawPoint = NSPoint(
+                x: ruleThickness - size.width - Self.horizontalPadding,
+                y: y + (position.height - size.height) / 2
+            )
+            numberString.draw(at: drawPoint, withAttributes: attributes)
+        }
+    }
+}
+
+// MARK: - Text storage delegate
+
+// @preconcurrency: the delegate protocol is nonisolated, but every edit to
+// an NSTextView's storage happens on the main thread; the conformance
+// asserts that at runtime instead of infecting the class with nonisolated
+// members.
+extension LineNumberGutterView: @preconcurrency NSTextStorageDelegate {
+    func textStorage(_ textStorage: NSTextStorage,
+                     didProcessEditing editedMask: NSTextStorageEditActions,
+                     range editedRange: NSRange,
+                     changeInLength delta: Int) {
+        // Markdown styling passes edit attributes constantly; only
+        // character edits can move line starts.
+        guard editedMask.contains(.editedCharacters) else { return }
+
+        let digitsBefore = String(lineIndex.lineCount).count
+        lineIndex.applyEdit(in: textStorage.string as NSString,
+                            editedRange: editedRange,
+                            changeInLength: delta)
+        if String(lineIndex.lineCount).count != digitsBefore {
+            updateThickness()
+        }
+        needsDisplay = true
+    }
+}

--- a/Jot/Editor/LineNumberGutter.swift
+++ b/Jot/Editor/LineNumberGutter.swift
@@ -2,6 +2,8 @@
 //  LineNumberGutter.swift
 //  Jot
 //
+//  Created on 8/9/26.
+//
 //  Line number gutter for the editor (#42), rebuilt on NSRulerView.
 //
 //  The first attempt (feature/42-line-number-gutter) drew numbers in the
@@ -15,6 +17,7 @@
 //
 
 import Cocoa
+import os.signpost
 
 // MARK: - Scroll view geometry
 //
@@ -30,6 +33,12 @@ import Cocoa
 // understands, so wrap width follows for free (#104) — and GutterClipView
 // refuses the OS's overlay rest-position shift, which would otherwise open
 // a dead gutter-width gap between the numbers and the text.
+//
+// One more empirically-established behavior matters here: NSTextView
+// resyncs its own frame to clip frame changes through a private
+// notification handler, bypassing autoresizing masks entirely. tile()
+// works around the layout cost of that resync — see the comment there
+// (#178).
 
 /// The editor's scroll view (set as a custom class in the storyboard).
 final class GutterScrollView: NSScrollView {
@@ -38,8 +47,9 @@ final class GutterScrollView: NSScrollView {
     // Without the gutter that didn't matter — the clip tracked the frame
     // and text reflowed continuously. With the clip's placement owned by
     // tile(), deferred tiling means text that only reflows on mouse-up.
-    // Retiling here restores the continuous reflow; tile() is idempotent
-    // and cheap, so the redundant calls outside live resize are fine.
+    // Retiling here restores the continuous reflow; a no-op tile() no
+    // longer touches the text container (see tile() below), so the
+    // redundant calls outside live resize are fine.
     override func setFrameSize(_ newSize: NSSize) {
         super.setFrameSize(newSize)
         if rulersVisible {
@@ -48,8 +58,62 @@ final class GutterScrollView: NSScrollView {
     }
 
     override func tile() {
+        guard rulersVisible, verticalRulerView != nil else {
+            super.tile()
+            return
+        }
+
+        // super.tile() re-lays the clip at full width on every call, and
+        // retileBesideRuler() re-shrinks it. Each clip frame write reaches
+        // the text view — not through autoresizing, but through NSTextView's
+        // private clip-frame-notification handler, which resizes the text
+        // view directly (and, on some paths, to the wrong width: clip minus
+        // ruler thickness a second time). With widthTracksTextView on, every
+        // one of those resizes pushes a new container width, and each new
+        // width invalidates layout for the WHOLE document — a ~250 ms
+        // re-layout on a 1 MB file, paid per keystroke near the bottom
+        // (contiguous layout re-lays everything above the caret) and per
+        // live-resize frame (#178).
+        //
+        // So: suspend width tracking while the frames dance, then apply the
+        // net result exactly once — the text view flaps harmlessly (frame
+        // changes without a container update cost no layout), and the
+        // container sees either no change (redundant tile: zero
+        // invalidations) or one change (real resize: one invalidation,
+        // the same as a gutterless scroll view).
+        let textView = documentView as? NSTextView
+        let container = textView?.textContainer
+        let restoreTracking = container?.widthTracksTextView ?? false
+        container?.widthTracksTextView = false
+
         super.tile()
-        guard rulersVisible, let ruler = verticalRulerView else { return }
+        retileBesideRuler()
+
+        var wrapWidthChanged = false
+        if let textView {
+            let targetWidth = contentView.bounds.width
+            if textView.frame.width != targetWidth {
+                textView.setFrameSize(NSSize(width: targetWidth,
+                                             height: textView.frame.height))
+            }
+            if restoreTracking, let container {
+                container.widthTracksTextView = true
+                // The width a tracking container derives from this frame
+                // (lineFragmentPadding lives inside the container).
+                let targetContainerWidth = max(targetWidth - 2 * textView.textContainerInset.width, 0)
+                if container.size.width != targetContainerWidth {
+                    wrapWidthChanged = true
+                    container.size = NSSize(width: targetContainerWidth,
+                                            height: container.size.height)
+                }
+            }
+        }
+        os_signpost(.event, log: PerformanceLog.log, name: "Gutter Tile",
+                    "wrapWidthChanged: %d", wrapWidthChanged ? 1 : 0)
+    }
+
+    private func retileBesideRuler() {
+        guard let ruler = verticalRulerView else { return }
 
         let clipFrame = contentView.frame
         let inset = min(ruler.requiredThickness, clipFrame.maxX)

--- a/Jot/Editor/LineNumberGutter.swift
+++ b/Jot/Editor/LineNumberGutter.swift
@@ -10,46 +10,68 @@
 //  text view's background behind a textContainerOrigin offset, which meant
 //  hand-synchronizing the container width with the inset on every toggle,
 //  resize, and wrap change — and it got that wrong in ways that clipped
-//  text (#104). Here the geometry lives in exactly one place —
-//  GutterScrollView.tile() below — and everything else follows from the
-//  clip view's frame, which the text system already tracks. Invalidating
-//  the gutter also no longer redraws the text (#103).
+//  text (#104). Here the geometry is owned by GutterClipView, which
+//  intercepts every frame change and enforces the ruler inset — the clip
+//  never accepts a wrong width, so widthTracksTextView and the text
+//  system follow for free. Invalidating the gutter does not redraw the
+//  text (#103).
 //
 
 import Cocoa
-import os.signpost
 
 // MARK: - Scroll view geometry
 //
-// Current macOS treats vertical rulers as an overlay and applies its own
-// accommodation — but lazily and only partially in this configuration:
-// nothing happens until the first live resize (ruler overlaps the text at
-// launch), and after one it shifts the content's rest position without
-// narrowing the tracked text width (right edge wraps out of view). All of
-// this was established empirically with on-screen windows; none of it is
-// something to rely on. So both halves of the geometry are owned here,
-// deterministically: GutterScrollView.tile() reserves the ruler's strip by
-// shrinking the clip view — the arrangement widthTracksTextView already
-// understands, so wrap width follows for free (#104) — and GutterClipView
-// refuses the OS's overlay rest-position shift, which would otherwise open
-// a dead gutter-width gap between the numbers and the text.
+// NSScrollView.tile() lays the clip view at full scroll-view width on
+// every call, then expects subclasses to carve out ruler space. But
+// NSTextView tracks clip-frame changes through a private notification
+// handler (_superviewClipViewFrameChanged:), so the brief full-width
+// frame reaches the text view and — with widthTracksTextView — pushes
+// a new container width, invalidating layout for the entire document.
+// On a 1 MB file that costs ~250 ms per tile(), paid per keystroke
+// near the bottom (contiguous layout re-lays everything above the
+// caret) and per live-resize frame (#178).
 //
-// One more empirically-established behavior matters here: NSTextView
-// resyncs its own frame to clip frame changes through a private
-// notification handler, bypassing autoresizing masks entirely. tile()
-// works around the layout cost of that resync — see the comment there
-// (#178).
+// CotEditor (coteditor/CotEditor, FB23993752) solved the same problem
+// by making the clip view the geometry owner: it overrides setFrameSize
+// and setFrameOrigin to substitute the correct inset frame, so the
+// clip never accepts the wrong geometry and nothing downstream needs
+// guarding. Jot adopts the same pattern: GutterScrollView.tile() tells
+// GutterClipView how much space the ruler needs before calling
+// super.tile(), and the clip view enforces that inset on every frame
+// change — the oscillation never starts.
 
 /// The editor's scroll view (set as a custom class in the storyboard).
 final class GutterScrollView: NSScrollView {
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        configureScrollingBehavior()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        configureScrollingBehavior()
+    }
+
+    private func configureScrollingBehavior() {
+        // The OS's overlay-ruler accommodation adds a left content inset
+        // that creates real horizontal scroll range. tile() reserves the
+        // ruler's strip deterministically, so decline the automatic one.
+        automaticallyAdjustsContentInsets = false
+        contentInsets = NSEdgeInsetsZero
+        // Jot soft-wraps by default — no legitimate horizontal scrolling.
+        // With .automatic elasticity, diagonal swipes rubber-band the text
+        // sideways even with zero real range (only observable when a ruler
+        // is installed; without one AppKit's scroll thread doesn't try).
+        // toggleWordWrap flips to .automatic when wrap is off.
+        horizontalScrollElasticity = .none
+    }
 
     // During a live drag AppKit defers tiling to the end of the resize.
     // Without the gutter that didn't matter — the clip tracked the frame
     // and text reflowed continuously. With the clip's placement owned by
     // tile(), deferred tiling means text that only reflows on mouse-up.
-    // Retiling here restores the continuous reflow; a no-op tile() no
-    // longer touches the text container (see tile() below), so the
-    // redundant calls outside live resize are fine.
+    // Retiling here restores the continuous reflow.
     override func setFrameSize(_ newSize: NSSize) {
         super.setFrameSize(newSize)
         if rulersVisible {
@@ -58,94 +80,102 @@ final class GutterScrollView: NSScrollView {
     }
 
     override func tile() {
-        guard rulersVisible, verticalRulerView != nil else {
+        let gutterClip = contentView as? GutterClipView
+
+        guard rulersVisible, let ruler = verticalRulerView else {
+            gutterClip?.rulerInset = 0
             super.tile()
             return
         }
 
-        // super.tile() re-lays the clip at full width on every call, and
-        // retileBesideRuler() re-shrinks it. Each clip frame write reaches
-        // the text view — not through autoresizing, but through NSTextView's
-        // private clip-frame-notification handler, which resizes the text
-        // view directly (and, on some paths, to the wrong width: clip minus
-        // ruler thickness a second time). With widthTracksTextView on, every
-        // one of those resizes pushes a new container width, and each new
-        // width invalidates layout for the WHOLE document — a ~250 ms
-        // re-layout on a 1 MB file, paid per keystroke near the bottom
-        // (contiguous layout re-lays everything above the caret) and per
-        // live-resize frame (#178).
+        let inset = ruler.requiredThickness
+        gutterClip?.rulerInset = inset
+
+        // super.tile() will call setFrameOrigin/setFrameSize on the
+        // clip view, proposing full-width geometry. The clip view's
+        // overrides intercept those calls and substitute the inset
+        // frame, so the clip never flaps to full width and
+        // widthTracksTextView never sees a wrong value (#178).
         //
-        // So: suspend width tracking while the frames dance, then apply the
-        // net result exactly once — the text view flaps harmlessly (frame
-        // changes without a container update cost no layout), and the
-        // container sees either no change (redundant tile: zero
-        // invalidations) or one change (real resize: one invalidation,
-        // the same as a gutterless scroll view).
-        let textView = documentView as? NSTextView
-        let container = textView?.textContainer
-        let restoreTracking = container?.widthTracksTextView ?? false
-        container?.widthTracksTextView = false
+        // For the interception to fire, the clip must differ from what
+        // super.tile() will propose — otherwise NSView's no-op
+        // optimization skips the calls entirely. Ensuring the clip is
+        // at the inset frame (not full-width) guarantees super.tile()
+        // always calls through.
+        let target = NSRect(x: inset, y: contentView.frame.minY,
+                            width: bounds.width - inset,
+                            height: contentView.frame.height)
+        if contentView.frame != target {
+            contentView.frame = target
+        }
 
         super.tile()
-        retileBesideRuler()
 
-        var wrapWidthChanged = false
-        if let textView {
-            let targetWidth = contentView.bounds.width
-            if textView.frame.width != targetWidth {
-                textView.setFrameSize(NSSize(width: targetWidth,
+        // NSTextView's private clip-frame handler subtracts ruler
+        // thickness from the clip width when sizing the text view (the
+        // "partial overlay accommodation" that assumes the ruler
+        // overlaps the clip). The clip is stable — no oscillation —
+        // but the text view ends up one ruler-width too narrow.
+        //
+        // Only correct this when widthTracksTextView is on (soft wrap):
+        // the container derives its width from the text view's frame,
+        // so this single correction propagates. When wrap is off the
+        // text view's width is content-driven and must not be touched.
+        if let textView = documentView as? NSTextView,
+           textView.textContainer?.widthTracksTextView == true {
+            let clipWidth = contentView.bounds.width
+            if textView.frame.width != clipWidth {
+                textView.setFrameSize(NSSize(width: clipWidth,
                                              height: textView.frame.height))
             }
-            if restoreTracking, let container {
-                container.widthTracksTextView = true
-                // The width a tracking container derives from this frame
-                // (lineFragmentPadding lives inside the container).
-                let targetContainerWidth = max(targetWidth - 2 * textView.textContainerInset.width, 0)
-                if container.size.width != targetContainerWidth {
-                    wrapWidthChanged = true
-                    container.size = NSSize(width: targetContainerWidth,
-                                            height: container.size.height)
-                }
-            }
-        }
-        os_signpost(.event, log: PerformanceLog.log, name: "Gutter Tile",
-                    "wrapWidthChanged: %d", wrapWidthChanged ? 1 : 0)
-    }
-
-    private func retileBesideRuler() {
-        guard let ruler = verticalRulerView else { return }
-
-        let clipFrame = contentView.frame
-        let inset = min(ruler.requiredThickness, clipFrame.maxX)
-
-        // If a future macOS reserves ruler space in tile() again, the
-        // clip arrives already offset — normalize the ruler beside it
-        // and don't shrink a second time.
-        if clipFrame.minX >= inset {
-            ruler.frame = NSRect(x: clipFrame.minX - inset, y: clipFrame.minY,
-                                 width: inset, height: clipFrame.height)
-            return
         }
 
-        ruler.frame = NSRect(x: 0, y: clipFrame.minY,
-                             width: inset, height: clipFrame.height)
-        contentView.frame = NSRect(x: inset, y: clipFrame.minY,
-                                   width: clipFrame.maxX - inset,
-                                   height: clipFrame.height)
+        // Position the ruler beside the (now-stable) clip.
+        ruler.frame = NSRect(x: 0, y: contentView.frame.minY,
+                             width: inset, height: contentView.frame.height)
     }
 }
 
 /// The editor's clip view (set as a custom class in the storyboard).
+///
+/// Owns the inset geometry that reserves space for the vertical ruler.
+/// Every frame change proposed by super.tile() is intercepted and
+/// replaced with the correct inset frame, so the clip never flaps to
+/// full width and NSTextView's private clip-frame handler never sees a
+/// width change it shouldn't (#178).
 final class GutterClipView: NSClipView {
+
+    /// How much horizontal space to reserve for the ruler, set by
+    /// GutterScrollView.tile() before calling super.tile(). Zero when
+    /// no ruler is visible.
+    var rulerInset: CGFloat = 0
+
+    override func setFrameOrigin(_ newOrigin: NSPoint) {
+        if rulerInset > 0 {
+            super.setFrameOrigin(NSPoint(x: rulerInset, y: newOrigin.y))
+        } else {
+            super.setFrameOrigin(newOrigin)
+        }
+    }
+
+    override func setFrameSize(_ newSize: NSSize) {
+        if rulerInset > 0, let scrollView = superview as? NSScrollView {
+            let insetWidth = scrollView.bounds.width - rulerInset
+            super.setFrameSize(NSSize(width: insetWidth, height: newSize.height))
+        } else {
+            super.setFrameSize(newSize)
+        }
+    }
 
     override func constrainBoundsRect(_ proposedBounds: NSRect) -> NSRect {
         var bounds = super.constrainBoundsRect(proposedBounds)
-        // The OS proposes a rest position one ruler-width into negative x
-        // to slide content out from under an overlay ruler. tile() above
-        // already moved the clip itself, so accepting the shift too would
-        // indent the text a second gutter-width.
-        if let scrollView = enclosingScrollView, scrollView.rulersVisible {
-            bounds.origin.x = max(bounds.origin.x, 0)
+        if rulerInset > 0 {
+            // super thinks the document scrolls to -rulerThickness
+            // (the overlay accommodation for a ruler that overlaps the
+            // clip). The clip is already inset past the ruler, so that
+            // range is phantom — pin x to zero so the elastic scroll
+            // thread never sees leftward range to rubber-band into.
+            bounds.origin.x = 0
         }
         return bounds
     }

--- a/Jot/Editor/LineNumberGutter.swift
+++ b/Jot/Editor/LineNumberGutter.swift
@@ -340,6 +340,15 @@ final class LineNumberGutterView: NSRulerView {
         // out, or the index here goes silently stale.
         textView.textStorage?.delegate = self
 
+        // The gutter also owns the layout manager delegate slot (equally
+        // unused elsewhere), for one callback: didCompleteLayout. On a
+        // restored window the first draw can run before TextKit has laid
+        // out the restored scroll position — the glyph query comes back
+        // empty and the strip paints bare. The text view repaints itself
+        // when background layout catches up; this is the only hook that
+        // tells the gutter to do the same (#178).
+        textView.layoutManager?.delegate = self
+
         // Only the gutter redraws on caret movement — invalidating the
         // whole text view for a bold number forced a full glyph redraw per
         // keystroke on the old branch (#103).
@@ -377,20 +386,26 @@ final class LineNumberGutterView: NSRulerView {
         if let storage = textView?.textStorage, storage.delegate === self {
             storage.delegate = nil
         }
+        if let layoutManager = textView?.layoutManager, layoutManager.delegate === self {
+            layoutManager.delegate = nil
+        }
         NotificationCenter.default.removeObserver(self)
     }
 
     deinit {
-        // Backstop for paths that skip tearDown. NSTextStorage.delegate
-        // is assign, not weak — if it still points here after
-        // deallocation, the next edit is a use-after-free, so clearing
-        // it is the part of teardown that cannot be skipped (#178).
-        // Rulers deallocate on the main thread; assumeIsolated asserts
-        // that rather than trusting it.
+        // Backstop for paths that skip tearDown. Both delegate slots are
+        // assign, not weak — if either still points here after
+        // deallocation, the next edit or layout pass is a use-after-free,
+        // so clearing them is the part of teardown that cannot be
+        // skipped (#178). Rulers deallocate on the main thread;
+        // assumeIsolated asserts that rather than trusting it.
         NotificationCenter.default.removeObserver(self)
         MainActor.assumeIsolated {
             if let storage = textView?.textStorage, storage.delegate === self {
                 storage.delegate = nil
+            }
+            if let layoutManager = textView?.layoutManager, layoutManager.delegate === self {
+                layoutManager.delegate = nil
             }
         }
     }
@@ -553,6 +568,24 @@ final class LineNumberGutterView: NSRulerView {
             )
             numberString.draw(at: drawPoint, withAttributes: attributes)
         }
+    }
+}
+
+// MARK: - Layout manager delegate
+
+// @preconcurrency for the same reason as NSTextStorageDelegate below:
+// layout for an NSTextView happens on the main thread; the conformance
+// asserts that at runtime.
+extension LineNumberGutterView: @preconcurrency NSLayoutManagerDelegate {
+    // The one callback this delegate exists for: a restored window can
+    // draw before layout reaches the restored scroll position, and the
+    // glyph query in lineNumberPositions comes back empty. Each layout
+    // chunk that completes gets the gutter another look; needsDisplay
+    // coalesces, so a fully laid-out document costs nothing extra.
+    func layoutManager(_ layoutManager: NSLayoutManager,
+                       didCompleteLayoutFor textContainer: NSTextContainer?,
+                       atEnd layoutFinishedFlag: Bool) {
+        needsDisplay = true
     }
 }
 

--- a/Jot/Editor/LineNumberGutter.swift
+++ b/Jot/Editor/LineNumberGutter.swift
@@ -368,15 +368,31 @@ final class LineNumberGutterView: NSRulerView {
     /// Called by the editor before the gutter is removed from its scroll
     /// view, so a text edit arriving afterward doesn't message a ruler
     /// that is mid-teardown.
+    ///
+    /// Only clears the delegate slot if this gutter still owns it: a
+    /// stale gutter torn down after a replacement has claimed the slot
+    /// must not unregister the live one — that failure mode is silent
+    /// (numbers freeze, nothing crashes, no test fails) (#178).
     func tearDown() {
-        textView?.textStorage?.delegate = nil
+        if let storage = textView?.textStorage, storage.delegate === self {
+            storage.delegate = nil
+        }
         NotificationCenter.default.removeObserver(self)
     }
 
     deinit {
-        // Backstop for paths that skip tearDown. Matches the pattern in
-        // EditorViewController and WordCountPanelController.
+        // Backstop for paths that skip tearDown. NSTextStorage.delegate
+        // is assign, not weak — if it still points here after
+        // deallocation, the next edit is a use-after-free, so clearing
+        // it is the part of teardown that cannot be skipped (#178).
+        // Rulers deallocate on the main thread; assumeIsolated asserts
+        // that rather than trusting it.
         NotificationCenter.default.removeObserver(self)
+        MainActor.assumeIsolated {
+            if let storage = textView?.textStorage, storage.delegate === self {
+                storage.delegate = nil
+            }
+        }
     }
 
     // The text view is flipped; declaring the gutter flipped too keeps

--- a/Jot/Editor/LineNumberGutter.swift
+++ b/Jot/Editor/LineNumberGutter.swift
@@ -129,6 +129,14 @@ final class GutterScrollView: NSScrollView {
 
         super.tile()
 
+        // With autohiding legacy scrollers, super.tile() can decide the
+        // scroller's visibility after it proposed the clip's frame — the
+        // interception then computed the width from a stale scroller
+        // state. Poke the clip once more now that everything is settled:
+        // the override recomputes from the live scroller and no-ops when
+        // the width was already right.
+        contentView.setFrameSize(contentView.frame.size)
+
         // With no ruler registered, NSTextView's clip-frame handler
         // sizes the text view to the clip width with no ruler-thickness
         // subtraction — this reconcile should be a no-op. Kept as a
@@ -175,8 +183,20 @@ final class GutterClipView: NSClipView {
 
     override func setFrameSize(_ newSize: NSSize) {
         if rulerInset > 0, let scrollView = superview as? NSScrollView {
-            let insetWidth = scrollView.bounds.width - rulerInset
-            super.setFrameSize(NSSize(width: insetWidth, height: newSize.height))
+            var available = scrollView.bounds.width
+            // Overlay scrollers float above the content; legacy scrollers
+            // ("Show scroll bars: Always", or any plugged-in mouse) consume
+            // layout space on the trailing edge. Deriving the width from
+            // the scroll view's bounds alone would run the clip — and the
+            // text — underneath a legacy scroller (#178). Height needs no
+            // such correction: it passes through from super.tile()'s
+            // proposal, which already accounts for a horizontal scroller.
+            if scrollView.scrollerStyle == .legacy,
+               let scroller = scrollView.verticalScroller,
+               !scroller.isHidden {
+                available -= scroller.frame.width
+            }
+            super.setFrameSize(NSSize(width: available - rulerInset, height: newSize.height))
         } else {
             super.setFrameSize(newSize)
         }

--- a/Jot/Editor/LineNumberGutter.swift
+++ b/Jot/Editor/LineNumberGutter.swift
@@ -372,6 +372,11 @@ final class LineNumberGutterView: NSRulerView {
         // — which renders every document apparently empty.
         clipsToBounds = true
 
+        // Decorative for VoiceOver: the numbers duplicate position info the
+        // text view already provides, and NSRulerView otherwise exposes an
+        // empty, unlabeled AXRuler element in every editor window.
+        setAccessibilityElement(false)
+
         lineIndex.rebuild(from: textView.string as NSString)
         currentLine = lineIndex.lineNumber(forCharacterAt: textView.selectedRange().location)
         updateThickness()

--- a/Jot/Editor/LineNumberGutter.swift
+++ b/Jot/Editor/LineNumberGutter.swift
@@ -39,9 +39,27 @@ import Cocoa
 // GutterClipView how much space the ruler needs before calling
 // super.tile(), and the clip view enforces that inset on every frame
 // change — the oscillation never starts.
+//
+// The gutter is a plain subview of the scroll view, NOT registered as
+// verticalRulerView. Registering a ruler triggers a second AppKit
+// accommodation: NSClipView.constrainBoundsRect reports a phantom
+// -rulerThickness leftward scroll range (assuming an overlay ruler),
+// and the elastic scroll machinery caches that range before an
+// override can clamp it — a horizontal rubber-band with wrap on.
+// The class still subclasses NSRulerView for its thickness plumbing,
+// but AppKit never knows it exists (#178).
 
 /// The editor's scroll view (set as a custom class in the storyboard).
 final class GutterScrollView: NSScrollView {
+
+    /// The line number strip, installed as a plain subview — deliberately
+    /// NOT via verticalRulerView. Registering a ruler makes NSClipView's
+    /// constrainBoundsRect report a phantom -rulerThickness leftward
+    /// scroll range (the overlay accommodation), and the elastic scroll
+    /// machinery caches that range before any override can clamp it —
+    /// the source of the horizontal rubber-band with wrap on (#178).
+    /// As a plain subview the accommodation never engages.
+    weak var gutterView: LineNumberGutterView?
 
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
@@ -74,7 +92,7 @@ final class GutterScrollView: NSScrollView {
     // Retiling here restores the continuous reflow.
     override func setFrameSize(_ newSize: NSSize) {
         super.setFrameSize(newSize)
-        if rulersVisible {
+        if gutterView != nil {
             tile()
         }
     }
@@ -82,7 +100,7 @@ final class GutterScrollView: NSScrollView {
     override func tile() {
         let gutterClip = contentView as? GutterClipView
 
-        guard rulersVisible, let ruler = verticalRulerView else {
+        guard let ruler = gutterView else {
             gutterClip?.rulerInset = 0
             super.tile()
             return
@@ -111,16 +129,13 @@ final class GutterScrollView: NSScrollView {
 
         super.tile()
 
-        // NSTextView's private clip-frame handler subtracts ruler
-        // thickness from the clip width when sizing the text view (the
-        // "partial overlay accommodation" that assumes the ruler
-        // overlaps the clip). The clip is stable — no oscillation —
-        // but the text view ends up one ruler-width too narrow.
-        //
-        // Only correct this when widthTracksTextView is on (soft wrap):
-        // the container derives its width from the text view's frame,
-        // so this single correction propagates. When wrap is off the
-        // text view's width is content-driven and must not be touched.
+        // With no ruler registered, NSTextView's clip-frame handler
+        // sizes the text view to the clip width with no ruler-thickness
+        // subtraction — this reconcile should be a no-op. Kept as a
+        // self-healing guard: if any path leaves the tracked text view
+        // narrower or wider than its clip, wrap width goes visibly
+        // wrong. Only when widthTracksTextView is on (soft wrap); a
+        // wrap-off text view's width is content-driven and untouchable.
         if let textView = documentView as? NSTextView,
            textView.textContainer?.widthTracksTextView == true {
             let clipWidth = contentView.bounds.width
@@ -130,7 +145,7 @@ final class GutterScrollView: NSScrollView {
             }
         }
 
-        // Position the ruler beside the (now-stable) clip.
+        // Position the gutter strip beside the (now-stable) clip.
         ruler.frame = NSRect(x: 0, y: contentView.frame.minY,
                              width: inset, height: contentView.frame.height)
     }
@@ -167,18 +182,11 @@ final class GutterClipView: NSClipView {
         }
     }
 
-    override func constrainBoundsRect(_ proposedBounds: NSRect) -> NSRect {
-        var bounds = super.constrainBoundsRect(proposedBounds)
-        if rulerInset > 0 {
-            // super thinks the document scrolls to -rulerThickness
-            // (the overlay accommodation for a ruler that overlaps the
-            // clip). The clip is already inset past the ruler, so that
-            // range is phantom — pin x to zero so the elastic scroll
-            // thread never sees leftward range to rubber-band into.
-            bounds.origin.x = 0
-        }
-        return bounds
-    }
+    // No constrainBoundsRect override: with the gutter installed as a
+    // plain subview instead of verticalRulerView, super never reports
+    // the phantom -rulerThickness leftward range that the elastic
+    // scroll thread rubber-banded into (#178). Pinned by
+    // testNoPhantomLeftwardScrollRange.
 }
 
 // MARK: - LineIndex

--- a/Jot/Editor/LineNumberGutter.swift
+++ b/Jot/Editor/LineNumberGutter.swift
@@ -406,8 +406,10 @@ final class LineNumberGutterView: NSRulerView {
         )
         // Belt and suspenders for scroll sync: ruler views normally track
         // their scroll view, but layer-backed scroll views have a history
-        // of leaving rulers a frame behind. The clip view already posts
-        // bounds changes for the styling debounce.
+        // of leaving rulers a frame behind. The styling debounce also
+        // enables this flag, but the gutter must not depend on an
+        // unrelated feature for its repaints — set it here too.
+        scrollView.contentView.postsBoundsChangedNotifications = true
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(scrollViewDidScroll),

--- a/Jot/Markdown/ListMarker.swift
+++ b/Jot/Markdown/ListMarker.swift
@@ -2,6 +2,8 @@
 //  ListMarker.swift
 //  Jot
 //
+//  Created on 8/8/26.
+//
 //  Parses the list marker at the start of a markdown line. Shared by the
 //  Return-key list continuation (#143) and the checklist commands (#146).
 //

--- a/Jot/Models/PreferencesManager.swift
+++ b/Jot/Models/PreferencesManager.swift
@@ -2,6 +2,8 @@
 //  PreferencesManager.swift
 //  Jot
 //
+//  Created on 8/9/26.
+//
 //  Centralized access to UserDefaults preferences.
 //  Eliminates scattered raw string keys across ViewControllers.
 //

--- a/Jot/Models/PreferencesManager.swift
+++ b/Jot/Models/PreferencesManager.swift
@@ -22,6 +22,7 @@ class PreferencesManager {
         static let selectedFontName = "selectedFontName"
         static let selectedFontSize = "selectedFontSize"
         static let loadRemoteImages = "loadRemoteImages"
+        static let showLineNumbers = "showLineNumbers"
     }
 
     // MARK: - Font
@@ -50,5 +51,26 @@ class PreferencesManager {
     var loadRemoteImages: Bool {
         get { defaults.object(forKey: Key.loadRemoteImages) as? Bool ?? false }
         set { defaults.set(newValue, forKey: Key.loadRemoteImages) }
+    }
+
+    // MARK: - Editor
+
+    /// Posted when showLineNumbers changes, so open editors update live.
+    static let showLineNumbersDidChangeNotification = Notification.Name("JotShowLineNumbersDidChange")
+
+    /// Single source of truth for the line number gutter. The View menu
+    /// toggle, the Settings popup, and every editor window all read and
+    /// write this one value — the first gutter branch kept a per-window
+    /// flag, this preference, and the Settings UI as three states that
+    /// never reconciled (#106). Same broadcast shape as
+    /// FontConfiguration.didChangeNotification (#124).
+    var showLineNumbers: Bool {
+        get { defaults.object(forKey: Key.showLineNumbers) as? Bool ?? true }
+        set {
+            guard newValue != showLineNumbers else { return }
+            defaults.set(newValue, forKey: Key.showLineNumbers)
+            NotificationCenter.default.post(
+                name: Self.showLineNumbersDidChangeNotification, object: self)
+        }
     }
 }

--- a/Jot/Models/TextStatistics.swift
+++ b/Jot/Models/TextStatistics.swift
@@ -2,6 +2,8 @@
 //  TextStatistics.swift
 //  Jot
 //
+//  Created on 8/7/26.
+//
 //  Shared text statistics calculations used by EditorViewController
 //  and WordCountPanelController.
 //

--- a/Jot/Resources/Base.lproj/Main.storyboard
+++ b/Jot/Resources/Base.lproj/Main.storyboard
@@ -638,6 +638,11 @@
                                                 <action selector="toggleEditorMode:" target="Ady-hI-5gd" id="DU3-fS-9k1"/>
                                             </connections>
                                         </menuItem>
+                                        <menuItem title="Hide Line Numbers" keyEquivalent="L" id="Lnm-mi-001">
+                                            <connections>
+                                                <action selector="toggleLineNumbers:" target="Voe-Tx-rLC" id="Lnm-ac-001"/>
+                                            </connections>
+                                        </menuItem>
                                         <menuItem isSeparatorItem="YES" id="hB3-LF-h0Y"/>
                                         <menuItem title="Show Sidebar" keyEquivalent="s" id="kIP-vf-haE">
                                             <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>
@@ -764,9 +769,9 @@
                         <rect key="frame" x="0.0" y="0.0" width="480" height="300"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
-                            <scrollView wantsLayer="YES" borderType="none" autohidesScrollers="YES" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" translatesAutoresizingMaskIntoConstraints="NO" id="Pqd-i5-fGZ">
+                            <scrollView wantsLayer="YES" borderType="none" autohidesScrollers="YES" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" translatesAutoresizingMaskIntoConstraints="NO" id="Pqd-i5-fGZ" customClass="GutterScrollView" customModule="Jot" customModuleProvider="target">
                                 <rect key="frame" x="0.0" y="31" width="480" height="269"/>
-                                <clipView key="contentView" drawsBackground="NO" id="scj-SS-mbZ">
+                                <clipView key="contentView" drawsBackground="NO" id="scj-SS-mbZ" customClass="GutterClipView" customModule="Jot" customModuleProvider="target">
                                     <rect key="frame" x="0.0" y="0.0" width="480" height="269"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>

--- a/Jot/Resources/index.html
+++ b/Jot/Resources/index.html
@@ -81,6 +81,9 @@
 
 		<h3>Markdown Preview</h3>
 		<p>Selecting <code>View &gt; Markdown Preview</code> (<kbd>&#8997;&#8984;P</kbd>) will open Markdown Preview. This parses your file&rsquo;s content and renders it as HTML. Note: previews do not live-update. Select it again to refresh the preview from what you&rsquo;ve written since.</p>
+
+		<h3>Line Numbers</h3>
+		<p>Each editor window can show line numbers in a gutter along the left edge. The number for the line you&rsquo;re on is bold. A long line that wraps counts as one line &mdash; the gutter numbers your lines, not your window&rsquo;s rows. Toggle them with <code>View &gt; Hide Line Numbers</code> (<kbd>&#8679;&#8984;L</kbd>) or in Settings; the switch applies to every open window at once.</p>
 	</section>
 
 	<section id="markdown-guide">

--- a/Jot/Windows/AboutWindowControllerProgrammatic.swift
+++ b/Jot/Windows/AboutWindowControllerProgrammatic.swift
@@ -2,6 +2,8 @@
 //  AboutWindowControllerProgrammatic.swift
 //  Jot
 //
+//  Created on 8/8/26.
+//
 //  Programmatic About window -- no storyboard required.
 //
 

--- a/Jot/Windows/AcknowledgementsWindowController.swift
+++ b/Jot/Windows/AcknowledgementsWindowController.swift
@@ -2,6 +2,8 @@
 //  AcknowledgementsWindowController.swift
 //  Jot
 //
+//  Created on 8/8/26.
+//
 //  Read-only in-app viewer for Acknowledgements.txt. Opening the file
 //  externally sent it to an editor as an editable document whose save
 //  would always fail (the signed bundle is read-only).

--- a/Jot/Windows/SettingsPanelController.swift
+++ b/Jot/Windows/SettingsPanelController.swift
@@ -2,6 +2,8 @@
 //  SettingsPanelController.swift
 //  Jot
 //
+//  Created on 8/9/26.
+//
 //  Programmatic Settings window -- no storyboard required.
 //  Font selection uses the system NSFontPanel.
 //
@@ -42,8 +44,13 @@ class SettingsPanelController: NSWindowController, NSWindowDelegate {
     @objc private func showLineNumbersDidChange(_ notification: Notification) {
         // The View menu can flip the preference while this panel is open;
         // the popup has to follow or it becomes a second source of truth —
-        // the exact disease #106 is about
-        lineNumbersPopup.selectItem(withTitle: PreferencesManager.shared.showLineNumbers ? "On" : "Off")
+        // the exact disease #106 is about.
+        // The popup only exists after setupContentView(), which only
+        // convenience init() calls — a panel built via init(window:) or
+        // init?(coder:) observes this notification with no popup to
+        // update, and the implicit unwrap would crash it (#178).
+        guard let popup = lineNumbersPopup else { return }
+        popup.selectItem(withTitle: PreferencesManager.shared.showLineNumbers ? "On" : "Off")
     }
 
     /// Registered from every initializer, not just convenience init(): a
@@ -201,6 +208,9 @@ class SettingsPanelController: NSWindowController, NSWindowDelegate {
     }
 
     private func updateFontPreview(_ font: NSFont) {
+        // Same shape as showLineNumbersDidChange: reachable from the
+        // font-change observer on panels that never ran setupContentView()
+        guard fontPreviewLabel != nil else { return }
         let displayName = font.displayName ?? font.fontName
         let size = Int(font.pointSize)
         fontPreviewLabel.stringValue = "\(displayName), \(size) pt"

--- a/Jot/Windows/SettingsPanelController.swift
+++ b/Jot/Windows/SettingsPanelController.swift
@@ -12,6 +12,7 @@ import Cocoa
 class SettingsPanelController: NSWindowController, NSWindowDelegate {
 
     private var fontPreviewLabel: NSTextField!
+    private var lineNumbersPopup: NSPopUpButton!
     private var remoteImagesPopup: NSPopUpButton!
 
     // MARK: - Initialization
@@ -38,11 +39,18 @@ class SettingsPanelController: NSWindowController, NSWindowDelegate {
         updateFontPreview(FontConfiguration.shared.resolvedFont())
     }
 
+    @objc private func showLineNumbersDidChange(_ notification: Notification) {
+        // The View menu can flip the preference while this panel is open;
+        // the popup has to follow or it becomes a second source of truth —
+        // the exact disease #106 is about
+        lineNumbersPopup.selectItem(withTitle: PreferencesManager.shared.showLineNumbers ? "On" : "Off")
+    }
+
     /// Registered from every initializer, not just convenience init(): a
     /// panel built through init(window:) or init?(coder:) would otherwise
     /// have a preview that silently never updates, hidden by the
     /// loadCurrentValues() call in showWindow (#124).
-    private func observeFontConfiguration() {
+    private func observeSharedState() {
         // Keep the preview current when the font changes from anywhere,
         // not just this panel
         NotificationCenter.default.addObserver(
@@ -51,16 +59,22 @@ class SettingsPanelController: NSWindowController, NSWindowDelegate {
             name: FontConfiguration.didChangeNotification,
             object: FontConfiguration.shared
         )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(showLineNumbersDidChange),
+            name: PreferencesManager.showLineNumbersDidChangeNotification,
+            object: nil
+        )
     }
 
     override init(window: NSWindow?) {
         super.init(window: window)
-        observeFontConfiguration()
+        observeSharedState()
     }
 
     required init?(coder: NSCoder) {
         super.init(coder: coder)
-        observeFontConfiguration()
+        observeSharedState()
     }
 
     deinit {
@@ -90,6 +104,20 @@ class SettingsPanelController: NSWindowController, NSWindowDelegate {
         fontButton.bezelStyle = .rounded
         fontButton.setAccessibilityLabel("Choose font")
 
+        // Line numbers row. The visible and accessibility labels match
+        // deliberately: the old branch's a11y label added a "for new
+        // editors" caveat sighted users never saw (#106). The setting is
+        // live-global now, so there is no caveat to admit.
+        let lineNumbersLabel = makeLabel("Line numbers:")
+        lineNumbersLabel.setAccessibilityLabel("Line numbers")
+
+        lineNumbersPopup = NSPopUpButton(frame: .zero, pullsDown: false)
+        lineNumbersPopup.translatesAutoresizingMaskIntoConstraints = false
+        lineNumbersPopup.addItems(withTitles: ["On", "Off"])
+        lineNumbersPopup.target = self
+        lineNumbersPopup.action = #selector(lineNumbersChanged(_:))
+        lineNumbersPopup.setAccessibilityLabel("Line numbers")
+
         // Remote images row
         let remoteImagesLabel = makeLabel("Remote images:")
         remoteImagesLabel.setAccessibilityLabel("Remote images in preview")
@@ -111,6 +139,8 @@ class SettingsPanelController: NSWindowController, NSWindowDelegate {
         contentView.addSubview(fontLabel)
         contentView.addSubview(fontPreviewLabel)
         contentView.addSubview(fontButton)
+        contentView.addSubview(lineNumbersLabel)
+        contentView.addSubview(lineNumbersPopup)
         contentView.addSubview(remoteImagesLabel)
         contentView.addSubview(remoteImagesPopup)
         contentView.addSubview(remoteImagesNote)
@@ -131,8 +161,16 @@ class SettingsPanelController: NSWindowController, NSWindowDelegate {
             fontButton.centerYAnchor.constraint(equalTo: fontLabel.centerYAnchor),
             fontButton.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -margin),
 
+            // Line numbers label
+            lineNumbersLabel.topAnchor.constraint(equalTo: fontLabel.bottomAnchor, constant: rowSpacing * 2),
+            lineNumbersLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: margin),
+
+            // Line numbers popup
+            lineNumbersPopup.centerYAnchor.constraint(equalTo: lineNumbersLabel.centerYAnchor),
+            lineNumbersPopup.leadingAnchor.constraint(equalTo: lineNumbersLabel.trailingAnchor, constant: 8),
+
             // Remote images label
-            remoteImagesLabel.topAnchor.constraint(equalTo: fontLabel.bottomAnchor, constant: rowSpacing * 2),
+            remoteImagesLabel.topAnchor.constraint(equalTo: lineNumbersLabel.bottomAnchor, constant: rowSpacing * 2),
             remoteImagesLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: margin),
 
             // Remote images popup
@@ -158,6 +196,7 @@ class SettingsPanelController: NSWindowController, NSWindowDelegate {
     private func loadCurrentValues() {
         let fontConfig = FontConfiguration.shared
         updateFontPreview(fontConfig.currentFont)
+        lineNumbersPopup.selectItem(withTitle: PreferencesManager.shared.showLineNumbers ? "On" : "Off")
         remoteImagesPopup.selectItem(withTitle: PreferencesManager.shared.loadRemoteImages ? "On" : "Off")
     }
 
@@ -189,6 +228,12 @@ class SettingsPanelController: NSWindowController, NSWindowDelegate {
         // notification reaches every window (#124). The preview label
         // updates via the same notification.
         FontConfiguration.shared.applyFont(newFont)
+    }
+
+    @objc private func lineNumbersChanged(_ sender: NSPopUpButton) {
+        // The preference setter broadcasts the change; open editors and
+        // the View menu title follow from there (#106)
+        PreferencesManager.shared.showLineNumbers = (sender.titleOfSelectedItem == "On")
     }
 
     @objc private func remoteImagesChanged(_ sender: NSPopUpButton) {

--- a/Jot/Windows/WordCountPanelController.swift
+++ b/Jot/Windows/WordCountPanelController.swift
@@ -2,6 +2,8 @@
 //  WordCountPanelController.swift
 //  Jot
 //
+//  Created on 8/8/26.
+//
 //  Programmatic floating utility panel for word count and
 //  text statistics. Tracks the active editor window.
 //

--- a/JotTests/LineNumberGutterTests.swift
+++ b/JotTests/LineNumberGutterTests.swift
@@ -401,12 +401,15 @@ final class LineNumberGutterTests: XCTestCase {
     // that skip tearDown — the failure modes are a silent freeze and a
     // use-after-free, neither of which any other test would catch.
 
-    func testTearDownClearsOwnedDelegate() {
+    func testTearDownClearsOwnedDelegates() {
         let (_, textView, gutter) = makeGutter(text: "one\ntwo")
         XCTAssertTrue(textView.textStorage?.delegate === gutter,
-                      "sanity: the gutter owns the delegate slot after install")
+                      "sanity: the gutter owns the storage delegate slot after install")
+        XCTAssertTrue(textView.layoutManager?.delegate === gutter,
+                      "sanity: the gutter owns the layout delegate slot after install")
         gutter.tearDown()
         XCTAssertNil(textView.textStorage?.delegate)
+        XCTAssertNil(textView.layoutManager?.delegate)
     }
 
     func testStaleTearDownLeavesTheLiveDelegateAlone() {
@@ -423,6 +426,8 @@ final class LineNumberGutterTests: XCTestCase {
         staleGutter.tearDown()
         XCTAssertTrue(textView.textStorage?.delegate === liveGutter,
                       "a stale gutter must not unregister the live one")
+        XCTAssertTrue(textView.layoutManager?.delegate === liveGutter,
+                      "a stale gutter must not unregister the live layout delegate either")
 
         // And the live gutter really is still tracking edits.
         textView.textStorage?.replaceCharacters(in: NSRange(location: 0, length: 0),
@@ -448,6 +453,39 @@ final class LineNumberGutterTests: XCTestCase {
                      "sanity: nothing retains the gutter once the ruler slot is cleared")
         XCTAssertNil(keepTextView?.textStorage?.delegate,
                      "deinit must clear a delegate slot it still owns")
+        XCTAssertNil(keepTextView?.layoutManager?.delegate,
+                     "deinit must clear the layout delegate slot too")
+    }
+
+    func testLayoutCompletionInvalidatesTheGutter() {
+        // The launch-paint bug: a restored window's first draw can run
+        // before TextKit lays out the restored scroll position, so the
+        // glyph query is empty and the strip paints bare. The text view
+        // repaints itself when background layout catches up; the gutter
+        // must get the same signal or it stays blank until first input.
+        let (scrollView, textView, gutter) = makeGutter(
+            text: String(repeating: "a line of ordinary text\n", count: 3000))
+        guard let layoutManager = textView.layoutManager,
+              let container = textView.textContainer else {
+            return XCTFail("text view lost its text system")
+        }
+
+        // needsDisplay is only tracked for views in a window; the launch
+        // bug is a windowed scenario, so give the gutter one.
+        let window = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 400, height: 300),
+                              styleMask: [.titled], backing: .buffered, defer: false)
+        window.contentView = scrollView
+
+        // Setup already laid everything out, so throw that layout away
+        // first — the launch scenario is exactly "layout not done yet."
+        let fullRange = NSRange(location: 0, length: (textView.string as NSString).length)
+        layoutManager.invalidateLayout(forCharacterRange: fullRange, actualCharacterRange: nil)
+        gutter.needsDisplay = false
+
+        layoutManager.ensureLayout(for: container)
+
+        XCTAssertTrue(gutter.needsDisplay,
+                      "completing layout must invalidate the gutter")
     }
 
     // MARK: - Preference (#106)

--- a/JotTests/LineNumberGutterTests.swift
+++ b/JotTests/LineNumberGutterTests.swift
@@ -202,9 +202,8 @@ final class LineNumberGutterTests: XCTestCase {
         textView.string = text
 
         let gutter = LineNumberGutterView(scrollView: scrollView, textView: textView)
-        scrollView.verticalRulerView = gutter
-        scrollView.hasVerticalRuler = true
-        scrollView.rulersVisible = true
+        scrollView.addSubview(gutter)
+        scrollView.gutterView = gutter
         scrollView.tile()
         return (scrollView, textView, gutter)
     }
@@ -379,6 +378,21 @@ final class LineNumberGutterTests: XCTestCase {
         XCTAssertEqual(textView.frame.width, wrapOffWidth)
     }
 
+    func testNoPhantomLeftwardScrollRange() {
+        // Installing the gutter via verticalRulerView made NSClipView's
+        // constrainBoundsRect report -rulerThickness of leftward scroll
+        // range (the overlay accommodation), and the elastic scroll
+        // machinery cached it before any override could clamp — the
+        // horizontal rubber-band with wrap on (#178). As a plain
+        // subview, the accommodation never engages: a leftward proposal
+        // must constrain to zero with no clamp of our own.
+        let (scrollView, _, _) = makeGutter(text: "one\ntwo")
+        let clip = scrollView.contentView
+        let proposed = NSRect(x: -50, y: 0,
+                              width: clip.bounds.width, height: clip.bounds.height)
+        XCTAssertEqual(clip.constrainBoundsRect(proposed).origin.x, 0)
+    }
+
     func testResizeStillReflowsTheText() {
         // The flip side of the no-op guard: a real width change must still
         // reach the text container, once, or wrap width goes stale.
@@ -419,7 +433,8 @@ final class LineNumberGutterTests: XCTestCase {
         // freeze, nothing crashes, no test fails.
         let (scrollView, textView, staleGutter) = makeGutter(text: "one\ntwo")
         let liveGutter = LineNumberGutterView(scrollView: scrollView, textView: textView)
-        scrollView.verticalRulerView = liveGutter
+        scrollView.addSubview(liveGutter)
+        scrollView.gutterView = liveGutter
         XCTAssertTrue(textView.textStorage?.delegate === liveGutter,
                       "sanity: the replacement claimed the slot on init")
 
@@ -447,7 +462,7 @@ final class LineNumberGutterTests: XCTestCase {
             let (scrollView, textView, gutter) = makeGutter(text: "one\ntwo")
             keepTextView = textView
             deallocatedGutter = gutter
-            scrollView.verticalRulerView = nil
+            gutter.removeFromSuperview()
         }
         XCTAssertNil(deallocatedGutter,
                      "sanity: nothing retains the gutter once the ruler slot is cleared")

--- a/JotTests/LineNumberGutterTests.swift
+++ b/JotTests/LineNumberGutterTests.swift
@@ -181,13 +181,22 @@ final class LineNumberGutterTests: XCTestCase {
     // MARK: - Mapping (real layout)
 
     /// A scroll view + text view + gutter with real TextKit layout, sized
-    /// so tests can force soft wrapping with a narrow width.
+    /// so tests can force soft wrapping with a narrow width. Uses the real
+    /// GutterScrollView/GutterClipView so the geometry layer — the part
+    /// resting on empirically-observed AppKit behavior — is what gets
+    /// exercised, not a plain NSScrollView stand-in (#178).
     private func makeGutter(text: String, width: CGFloat = 400)
-        -> (scrollView: NSScrollView, textView: NSTextView, gutter: LineNumberGutterView) {
+        -> (scrollView: GutterScrollView, textView: NSTextView, gutter: LineNumberGutterView) {
         let frame = NSRect(x: 0, y: 0, width: width, height: 300)
-        let scrollView = NSScrollView(frame: frame)
+        let scrollView = GutterScrollView(frame: frame)
+        let clipView = GutterClipView()
+        clipView.drawsBackground = false
+        scrollView.contentView = clipView
+
         let textView = NSTextView(frame: frame)
         textView.font = NSFont.systemFont(ofSize: 12)
+        textView.isVerticallyResizable = true
+        textView.autoresizingMask = [.width, .height]
         textView.textContainer?.widthTracksTextView = true
         scrollView.documentView = textView
         textView.string = text
@@ -196,6 +205,7 @@ final class LineNumberGutterTests: XCTestCase {
         scrollView.verticalRulerView = gutter
         scrollView.hasVerticalRuler = true
         scrollView.rulersVisible = true
+        scrollView.tile()
         return (scrollView, textView, gutter)
     }
 
@@ -277,6 +287,60 @@ final class LineNumberGutterTests: XCTestCase {
         textView.textStorage?.replaceCharacters(in: NSRange(location: 3, length: 0), with: "\ntwo\nthree")
         let numbers = gutter.lineNumberPositions(in: fullRect(of: textView)).map(\.number)
         XCTAssertEqual(numbers, [1, 2, 3])
+    }
+
+    // MARK: - Scroll view geometry (#178)
+
+    func testTileReservesTheGutterStrip() {
+        let (scrollView, textView, gutter) = makeGutter(text: "one\ntwo")
+        let clip = scrollView.contentView
+        // The clip starts one gutter-width in, the ruler fills that strip,
+        // and the wrap width follows the shrunken clip.
+        XCTAssertEqual(clip.frame.minX, gutter.requiredThickness)
+        XCTAssertEqual(gutter.frame.width, gutter.requiredThickness)
+        XCTAssertEqual(textView.frame.width, clip.bounds.width)
+    }
+
+    func testRedundantTileDoesNotInvalidateLayout() {
+        // The #178 performance bug: every tile() bounced the clip to full
+        // width and back, which invalidated layout for the whole document
+        // through widthTracksTextView. On a large file that made typing
+        // near the bottom (contiguous layout re-lays everything above the
+        // caret) and live resizes pay a full-document re-layout per event.
+        let (scrollView, textView, _) = makeGutter(
+            text: String(repeating: "a line of ordinary text\n", count: 3000))
+        guard let layoutManager = textView.layoutManager,
+              let container = textView.textContainer else {
+            return XCTFail("text view lost its text system")
+        }
+        layoutManager.ensureLayout(for: container)
+        let length = (textView.string as NSString).length
+        XCTAssertEqual(layoutManager.firstUnlaidCharacterIndex(), length,
+                       "sanity: the whole document is laid out")
+
+        scrollView.tile()
+        XCTAssertEqual(layoutManager.firstUnlaidCharacterIndex(), length,
+                       "a geometry-neutral tile() must not throw away layout")
+
+        // The live-resize path retiles on every frame; an unchanged size
+        // must also be layout-neutral.
+        scrollView.setFrameSize(scrollView.frame.size)
+        XCTAssertEqual(layoutManager.firstUnlaidCharacterIndex(), length,
+                       "a same-size setFrameSize must not throw away layout")
+    }
+
+    func testResizeStillReflowsTheText() {
+        // The flip side of the no-op guard: a real width change must still
+        // reach the text container, once, or wrap width goes stale.
+        let (scrollView, textView, _) = makeGutter(text: "one\ntwo", width: 400)
+        scrollView.setFrameSize(NSSize(width: 250, height: 300))
+        let clip = scrollView.contentView
+        XCTAssertEqual(textView.frame.width, clip.bounds.width)
+        XCTAssertEqual(textView.textContainer?.size.width,
+                       textView.frame.width - 2 * textView.textContainerInset.width)
+
+        scrollView.setFrameSize(NSSize(width: 500, height: 300))
+        XCTAssertEqual(textView.frame.width, scrollView.contentView.bounds.width)
     }
 
     // MARK: - Preference (#106)

--- a/JotTests/LineNumberGutterTests.swift
+++ b/JotTests/LineNumberGutterTests.swift
@@ -329,6 +329,56 @@ final class LineNumberGutterTests: XCTestCase {
                        "a same-size setFrameSize must not throw away layout")
     }
 
+    func testClipNeverFlapsToFullWidth() {
+        // The #178 root cause: super.tile() sets the clip to full scroll
+        // view width, and the old override shrunk it back — the oscillation
+        // invalidated layout. With the clip-view-interception pattern the
+        // clip never accepts the wrong frame in the first place.
+        let (scrollView, _, gutter) = makeGutter(text: "one\ntwo")
+        let clip = scrollView.contentView
+        let expectedClipWidth = scrollView.bounds.width - gutter.requiredThickness
+
+        // Repeated tiles must leave the clip at the inset width.
+        for _ in 0..<5 {
+            scrollView.tile()
+            XCTAssertEqual(clip.frame.width, expectedClipWidth)
+            XCTAssertEqual(clip.frame.minX, gutter.requiredThickness)
+        }
+    }
+
+    func testNoAutomaticContentInsets() {
+        // The OS's overlay-ruler accommodation adds a left content inset
+        // that creates real horizontal scroll range. tile() reserves the
+        // ruler's strip deterministically, so the automatic one is declined.
+        let (scrollView, textView, _) = makeGutter(text: "one\ntwo")
+        XCTAssertFalse(scrollView.automaticallyAdjustsContentInsets)
+        XCTAssertEqual(scrollView.contentInsets.left, 0)
+        XCTAssertEqual(textView.frame.width, scrollView.contentView.bounds.width)
+    }
+
+    func testTileLeavesWrapOffWidthAlone() {
+        // With word wrap off the text view's width is content-driven, not
+        // clip-driven. tile() must neither reconcile it to the clip nor
+        // let the clip-sync erode it (#178 follow-up: the first fix
+        // clobbered it, which killed horizontal scrolling in wrap-off).
+        let (scrollView, textView, _) = makeGutter(text: "a rather long line of text\nshort")
+        // Configure exactly what Format > Toggle Word Wrap does.
+        textView.textContainer?.widthTracksTextView = false
+        textView.textContainer?.containerSize = CGSize(width: CGFloat.greatestFiniteMagnitude,
+                                                       height: CGFloat.greatestFiniteMagnitude)
+        scrollView.hasHorizontalScroller = true
+        let wrapOffWidth = scrollView.frame.width * 2
+        textView.setFrameSize(CGSize(width: wrapOffWidth, height: textView.frame.height))
+
+        scrollView.tile()
+        XCTAssertEqual(textView.frame.width, wrapOffWidth)
+        XCTAssertEqual(textView.textContainer?.size.width, CGFloat.greatestFiniteMagnitude)
+        XCTAssertFalse(textView.textContainer?.widthTracksTextView ?? true)
+
+        scrollView.setFrameSize(scrollView.frame.size)
+        XCTAssertEqual(textView.frame.width, wrapOffWidth)
+    }
+
     func testResizeStillReflowsTheText() {
         // The flip side of the no-op guard: a real width change must still
         // reach the text container, once, or wrap width goes stale.

--- a/JotTests/LineNumberGutterTests.swift
+++ b/JotTests/LineNumberGutterTests.swift
@@ -158,11 +158,15 @@ final class LineNumberGutterTests: XCTestCase {
 
     // MARK: - Gutter width
 
-    func testThicknessGrowsAtDigitBoundaries() {
+    func testThicknessNeverShrinksAsDigitsGrow() {
+        // Not strict growth everywhere: at small fonts the 32 pt minimum
+        // swallows the 2 → 3 digit step, so 99 → 100 may hold width.
+        // What must hold is monotonicity, and strict growth once the digit
+        // width clears the floor.
         let font = NSFont.monospacedDigitSystemFont(ofSize: 11, weight: .regular)
-        let twoDigits = LineNumberGutterView.requiredThickness(forLineCount: 99, font: font)
-        let threeDigits = LineNumberGutterView.requiredThickness(forLineCount: 100, font: font)
-        let fourDigits = LineNumberGutterView.requiredThickness(forLineCount: 1000, font: font)
+        let twoDigits = LineNumberGutterView.thickness(forLineCount: 99, font: font)
+        let threeDigits = LineNumberGutterView.thickness(forLineCount: 100, font: font)
+        let fourDigits = LineNumberGutterView.thickness(forLineCount: 1000, font: font)
         XCTAssertLessThanOrEqual(twoDigits, threeDigits)
         XCTAssertLessThan(threeDigits, fourDigits)
     }
@@ -171,9 +175,9 @@ final class LineNumberGutterTests: XCTestCase {
         // A one-line document still gets a usable gutter, and 9 → 10
         // stays inside the two-digit reservation instead of jittering
         let font = NSFont.monospacedDigitSystemFont(ofSize: 11, weight: .regular)
-        let one = LineNumberGutterView.requiredThickness(forLineCount: 1, font: font)
-        let nine = LineNumberGutterView.requiredThickness(forLineCount: 9, font: font)
-        let ten = LineNumberGutterView.requiredThickness(forLineCount: 10, font: font)
+        let one = LineNumberGutterView.thickness(forLineCount: 1, font: font)
+        let nine = LineNumberGutterView.thickness(forLineCount: 9, font: font)
+        let ten = LineNumberGutterView.thickness(forLineCount: 10, font: font)
         XCTAssertEqual(one, nine)
         XCTAssertEqual(nine, ten)
     }

--- a/JotTests/LineNumberGutterTests.swift
+++ b/JotTests/LineNumberGutterTests.swift
@@ -378,6 +378,30 @@ final class LineNumberGutterTests: XCTestCase {
         XCTAssertEqual(textView.frame.width, wrapOffWidth)
     }
 
+    func testLegacyScrollersKeepTheClipClearOfTheScroller() {
+        // Overlay scrollers float above the content; legacy scrollers
+        // ("Show scroll bars: Always", or any plugged-in mouse) consume
+        // layout space on the trailing edge. The clip width is derived
+        // from the scroll view's bounds, so it must subtract a visible
+        // legacy scroller too — or the text runs underneath it (#178).
+        let (scrollView, textView, gutter) = makeGutter(text: "one\ntwo")
+        scrollView.hasVerticalScroller = true
+        scrollView.autohidesScrollers = false
+        scrollView.scrollerStyle = .legacy
+        scrollView.tile()
+
+        guard let scroller = scrollView.verticalScroller, !scroller.isHidden else {
+            return XCTFail("sanity: a non-autohiding legacy scroller must be visible")
+        }
+        XCTAssertGreaterThan(scroller.frame.width, 0,
+                             "sanity: a legacy scroller consumes real width")
+        let clip = scrollView.contentView
+        XCTAssertEqual(clip.frame.width,
+                       scrollView.bounds.width - gutter.requiredThickness - scroller.frame.width)
+        XCTAssertEqual(clip.frame.minX, gutter.requiredThickness)
+        XCTAssertEqual(textView.frame.width, clip.bounds.width)
+    }
+
     func testNoPhantomLeftwardScrollRange() {
         // Installing the gutter via verticalRulerView made NSClipView's
         // constrainBoundsRect report -rulerThickness of leftward scroll

--- a/JotTests/LineNumberGutterTests.swift
+++ b/JotTests/LineNumberGutterTests.swift
@@ -1,0 +1,345 @@
+//
+//  LineNumberGutterTests.swift
+//  JotTests
+//
+//  Tests for the line number gutter (#42): the LineIndex line-start cache
+//  (#103), the wrapped-line and trailing-line cases the first gutter
+//  branch got wrong (#102, #105), the width digit boundaries, and the
+//  showLineNumbers preference (#106, #108).
+//
+
+import XCTest
+@testable import Jot
+
+@MainActor
+final class LineNumberGutterTests: XCTestCase {
+
+    // MARK: - LineIndex: building
+
+    func testEmptyStringIsOneLine() {
+        let index = LineIndex(string: "")
+        XCTAssertEqual(index.lineStarts, [0])
+        XCTAssertEqual(index.lineCount, 1)
+    }
+
+    func testSingleLineWithoutTerminator() {
+        let index = LineIndex(string: "hello")
+        XCTAssertEqual(index.lineStarts, [0])
+        XCTAssertEqual(index.lineCount, 1)
+    }
+
+    func testTrailingNewlineAddsTheEmptyLastLine() {
+        // The caret can sit after the final newline; that position is a
+        // line and gets a number (#105)
+        let index = LineIndex(string: "hello\n")
+        XCTAssertEqual(index.lineStarts, [0, 6])
+        XCTAssertEqual(index.lineCount, 2)
+    }
+
+    func testMultipleLines() {
+        let index = LineIndex(string: "a\nbb\nccc")
+        XCTAssertEqual(index.lineStarts, [0, 2, 5])
+        XCTAssertEqual(index.lineCount, 3)
+    }
+
+    func testCRLFCountsAsOneTerminator() {
+        // CRLF is supported input (see DocumentTests); the pair is one
+        // line break, not two
+        let index = LineIndex(string: "a\r\nb")
+        XCTAssertEqual(index.lineStarts, [0, 3])
+        XCTAssertEqual(index.lineCount, 2)
+    }
+
+    func testLoneCarriageReturnIsATerminator() {
+        let index = LineIndex(string: "a\rb")
+        XCTAssertEqual(index.lineStarts, [0, 2])
+        XCTAssertEqual(index.lineCount, 2)
+    }
+
+    func testUnicodeLineSeparatorIsATerminator() {
+        let index = LineIndex(string: "a\u{2028}b")
+        XCTAssertEqual(index.lineStarts, [0, 2])
+        XCTAssertEqual(index.lineCount, 2)
+    }
+
+    // MARK: - LineIndex: lookups
+
+    func testLineNumberForCharacter() {
+        let index = LineIndex(string: "a\nbb\nccc")
+        XCTAssertEqual(index.lineNumber(forCharacterAt: 0), 1)
+        XCTAssertEqual(index.lineNumber(forCharacterAt: 1), 1)
+        XCTAssertEqual(index.lineNumber(forCharacterAt: 2), 2)
+        XCTAssertEqual(index.lineNumber(forCharacterAt: 4), 2)
+        XCTAssertEqual(index.lineNumber(forCharacterAt: 5), 3)
+        XCTAssertEqual(index.lineNumber(forCharacterAt: 8), 3)
+    }
+
+    func testCaretAfterTrailingNewlineIsOnTheLastLine() {
+        let index = LineIndex(string: "a\n")
+        XCTAssertEqual(index.lineNumber(forCharacterAt: 2), 2)
+    }
+
+    func testIsLineStart() {
+        let index = LineIndex(string: "a\nbb\nccc")
+        XCTAssertTrue(index.isLineStart(0))
+        XCTAssertFalse(index.isLineStart(1))
+        XCTAssertTrue(index.isLineStart(2))
+        XCTAssertFalse(index.isLineStart(3))
+        XCTAssertTrue(index.isLineStart(5))
+        XCTAssertFalse(index.isLineStart(8))
+    }
+
+    // MARK: - LineIndex: incremental updates
+
+    /// Applies one edit to both a working string and an incrementally
+    /// updated index, then asserts the incremental result matches a fresh
+    /// rebuild — the ground truth the incremental path must never drift
+    /// from.
+    private func applyAndCheck(_ edit: (range: NSRange, replacement: String),
+                               to text: NSMutableString,
+                               index: inout LineIndex,
+                               line: UInt = #line) {
+        let delta = (edit.replacement as NSString).length - edit.range.length
+        text.replaceCharacters(in: edit.range, with: edit.replacement)
+        index.applyEdit(in: text,
+                        editedRange: NSRange(location: edit.range.location,
+                                             length: (edit.replacement as NSString).length),
+                        changeInLength: delta)
+        XCTAssertEqual(index.lineStarts, LineIndex(string: text).lineStarts,
+                       "incremental index diverged after editing to: \(text)", line: line)
+    }
+
+    func testIncrementalEditsMatchFullRebuild() {
+        let text = NSMutableString(string: "")
+        var index = LineIndex(string: text)
+
+        // Type into an empty document
+        applyAndCheck((NSRange(location: 0, length: 0), "hello"), to: text, index: &index)
+        // Newline at the end
+        applyAndCheck((NSRange(location: 5, length: 0), "\n"), to: text, index: &index)
+        // Type on the trailing empty line
+        applyAndCheck((NSRange(location: 6, length: 0), "world"), to: text, index: &index)
+        // Multi-line paste in the middle
+        applyAndCheck((NSRange(location: 2, length: 0), "x\ny\nz"), to: text, index: &index)
+        // Delete a range spanning several lines
+        applyAndCheck((NSRange(location: 1, length: 8), ""), to: text, index: &index)
+        // Replace everything
+        applyAndCheck((NSRange(location: 0, length: text.length), "one\ntwo\nthree\n"), to: text, index: &index)
+        // Delete the final trailing newline
+        applyAndCheck((NSRange(location: text.length - 1, length: 1), ""), to: text, index: &index)
+        // Delete all
+        applyAndCheck((NSRange(location: 0, length: text.length), ""), to: text, index: &index)
+    }
+
+    func testIncrementalEditsAroundCRLFBoundaries() {
+        // The dangerous cases: an edit that splits or forms a CRLF pair
+        // moves a line start without touching the surrounding lines
+        let text = NSMutableString(string: "aa\r\nbb")
+        var index = LineIndex(string: text)
+
+        // Split the pair: delete the \n, leaving a lone \r terminator
+        applyAndCheck((NSRange(location: 3, length: 1), ""), to: text, index: &index)
+        // Re-form the pair: insert \n after the \r
+        applyAndCheck((NSRange(location: 3, length: 0), "\n"), to: text, index: &index)
+        // Insert a \r immediately before an existing \n, forming a pair
+        // out of two previously separate characters
+        applyAndCheck((NSRange(location: 0, length: text.length), "aa\nbb"), to: text, index: &index)
+        applyAndCheck((NSRange(location: 2, length: 0), "\r"), to: text, index: &index)
+        // Break that pair by typing between \r and \n
+        applyAndCheck((NSRange(location: 3, length: 0), "x"), to: text, index: &index)
+    }
+
+    func testIncrementalEditAtTheVeryEnd() {
+        let text = NSMutableString(string: "a\nb")
+        var index = LineIndex(string: text)
+        applyAndCheck((NSRange(location: 3, length: 0), "\n"), to: text, index: &index)
+        applyAndCheck((NSRange(location: 4, length: 0), "c"), to: text, index: &index)
+    }
+
+    // MARK: - Gutter width
+
+    func testThicknessGrowsAtDigitBoundaries() {
+        let font = NSFont.monospacedDigitSystemFont(ofSize: 11, weight: .regular)
+        let twoDigits = LineNumberGutterView.requiredThickness(forLineCount: 99, font: font)
+        let threeDigits = LineNumberGutterView.requiredThickness(forLineCount: 100, font: font)
+        let fourDigits = LineNumberGutterView.requiredThickness(forLineCount: 1000, font: font)
+        XCTAssertLessThanOrEqual(twoDigits, threeDigits)
+        XCTAssertLessThan(threeDigits, fourDigits)
+    }
+
+    func testThicknessHasAFloor() {
+        // A one-line document still gets a usable gutter, and 9 → 10
+        // stays inside the two-digit reservation instead of jittering
+        let font = NSFont.monospacedDigitSystemFont(ofSize: 11, weight: .regular)
+        let one = LineNumberGutterView.requiredThickness(forLineCount: 1, font: font)
+        let nine = LineNumberGutterView.requiredThickness(forLineCount: 9, font: font)
+        let ten = LineNumberGutterView.requiredThickness(forLineCount: 10, font: font)
+        XCTAssertEqual(one, nine)
+        XCTAssertEqual(nine, ten)
+    }
+
+    // MARK: - Mapping (real layout)
+
+    /// A scroll view + text view + gutter with real TextKit layout, sized
+    /// so tests can force soft wrapping with a narrow width.
+    private func makeGutter(text: String, width: CGFloat = 400)
+        -> (scrollView: NSScrollView, textView: NSTextView, gutter: LineNumberGutterView) {
+        let frame = NSRect(x: 0, y: 0, width: width, height: 300)
+        let scrollView = NSScrollView(frame: frame)
+        let textView = NSTextView(frame: frame)
+        textView.font = NSFont.systemFont(ofSize: 12)
+        textView.textContainer?.widthTracksTextView = true
+        scrollView.documentView = textView
+        textView.string = text
+
+        let gutter = LineNumberGutterView(scrollView: scrollView, textView: textView)
+        scrollView.verticalRulerView = gutter
+        scrollView.hasVerticalRuler = true
+        scrollView.rulersVisible = true
+        return (scrollView, textView, gutter)
+    }
+
+    private func fullRect(of textView: NSTextView) -> NSRect {
+        guard let layoutManager = textView.layoutManager,
+              let textContainer = textView.textContainer else { return .zero }
+        layoutManager.ensureLayout(for: textContainer)
+        return NSRect(origin: .zero,
+                      size: NSSize(width: textView.frame.width,
+                                   height: max(layoutManager.usedRect(for: textContainer).maxY + 100, 300)))
+    }
+
+    func testOneNumberPerLogicalLine() {
+        let (_, textView, gutter) = makeGutter(text: "one\ntwo\nthree")
+        let numbers = gutter.lineNumberPositions(in: fullRect(of: textView)).map(\.number)
+        XCTAssertEqual(numbers, [1, 2, 3])
+    }
+
+    func testWrappedLineGetsOneNumber() {
+        // A soft-wrapped line spans several fragments but is one line;
+        // only its first fragment is numbered
+        let (_, textView, gutter) = makeGutter(
+            text: String(repeating: "wrap ", count: 60) + "\nsecond",
+            width: 120
+        )
+        let positions = gutter.lineNumberPositions(in: fullRect(of: textView))
+        XCTAssertEqual(positions.map(\.number), [1, 2])
+        // Sanity-check that wrapping actually happened, or this test
+        // proves nothing: line 2 must start well below line 1's height
+        XCTAssertGreaterThan(positions[1].yInTextView, positions[0].height * 3)
+    }
+
+    func testViewportStartingMidWrappedLineNumbersCorrectly() {
+        // The first branch counted the wrapped line's continuation as a
+        // full line and drew every visible number one too high (#102).
+        // A viewport that starts inside line 1's soft wrap must label the
+        // next line "2".
+        let (_, textView, gutter) = makeGutter(
+            text: String(repeating: "wrap ", count: 60) + "\nsecond",
+            width: 120
+        )
+        let all = gutter.lineNumberPositions(in: fullRect(of: textView))
+        XCTAssertEqual(all.count, 2)
+
+        // A rect from one point inside line 1's second fragment down past
+        // line 2's top — the old prefix counter would have labeled line 2
+        // as "3" here
+        let midWrapY = all[0].yInTextView + all[0].height + 1
+        let midRect = NSRect(x: 0, y: midWrapY,
+                             width: 120, height: all[1].yInTextView - midWrapY + 30)
+        let numbers = gutter.lineNumberPositions(in: midRect).map(\.number)
+        XCTAssertEqual(numbers, [2])
+
+        // And a rect over continuation fragments only: no line starts, no
+        // numbers — continuation fragments are never labeled
+        let continuationRect = NSRect(x: 0, y: midWrapY, width: 120, height: all[0].height)
+        XCTAssertEqual(gutter.lineNumberPositions(in: continuationRect).map(\.number), [])
+    }
+
+    func testEmptyDocumentShowsLineOne() {
+        // The old glyph walk drew nothing for an empty document (#105)
+        let (_, textView, gutter) = makeGutter(text: "")
+        let numbers = gutter.lineNumberPositions(in: fullRect(of: textView)).map(\.number)
+        XCTAssertEqual(numbers, [1])
+    }
+
+    func testTrailingEmptyLineIsNumbered() {
+        // "a\n" is two lines; the second has no glyphs, only the extra
+        // line fragment where the caret sits (#105)
+        let (_, textView, gutter) = makeGutter(text: "a\n")
+        let numbers = gutter.lineNumberPositions(in: fullRect(of: textView)).map(\.number)
+        XCTAssertEqual(numbers, [1, 2])
+    }
+
+    func testIndexTracksLiveEdits() {
+        // The gutter is the text storage delegate; typing must keep the
+        // index current without a rebuild call from anyone
+        let (_, textView, gutter) = makeGutter(text: "one")
+        textView.textStorage?.replaceCharacters(in: NSRange(location: 3, length: 0), with: "\ntwo\nthree")
+        let numbers = gutter.lineNumberPositions(in: fullRect(of: textView)).map(\.number)
+        XCTAssertEqual(numbers, [1, 2, 3])
+    }
+
+    // MARK: - Preference (#106)
+
+    /// Same save/restore pattern as the font tests; #174 tracks moving
+    /// all preference tests onto an injected throwaway UserDefaults.
+    private func withSavedLineNumbersPreference(_ body: () throws -> Void) rethrows {
+        let saved = PreferencesManager.shared.showLineNumbers
+        defer { PreferencesManager.shared.showLineNumbers = saved }
+        try body()
+    }
+
+    func testShowLineNumbersDefaultsToOn() {
+        withSavedLineNumbersPreference {
+            UserDefaults.standard.removeObject(forKey: "showLineNumbers")
+            XCTAssertTrue(PreferencesManager.shared.showLineNumbers)
+        }
+    }
+
+    func testShowLineNumbersPersists() {
+        withSavedLineNumbersPreference {
+            PreferencesManager.shared.showLineNumbers = false
+            XCTAssertFalse(PreferencesManager.shared.showLineNumbers)
+            XCTAssertFalse(UserDefaults.standard.bool(forKey: "showLineNumbers"))
+        }
+    }
+
+    /// Mutable notification counter that block observers can capture under
+    /// strict concurrency. The posts under test are synchronous on the
+    /// main thread, so the unchecked marker is honest.
+    private final class Counter: @unchecked Sendable {
+        var value = 0
+    }
+
+    func testChangingThePreferencePostsExactlyOneNotification() {
+        withSavedLineNumbersPreference {
+            PreferencesManager.shared.showLineNumbers = true
+
+            let received = Counter()
+            let token = NotificationCenter.default.addObserver(
+                forName: PreferencesManager.showLineNumbersDidChangeNotification,
+                object: nil, queue: nil) { _ in received.value += 1 }
+            defer { NotificationCenter.default.removeObserver(token) }
+
+            PreferencesManager.shared.showLineNumbers = false
+            XCTAssertEqual(received.value, 1)
+        }
+    }
+
+    func testWritingTheSameValuePostsNothing() {
+        // Every editor window re-lays-out on this notification; a no-op
+        // write must not fan out as a change
+        withSavedLineNumbersPreference {
+            PreferencesManager.shared.showLineNumbers = true
+
+            let received = Counter()
+            let token = NotificationCenter.default.addObserver(
+                forName: PreferencesManager.showLineNumbersDidChangeNotification,
+                object: nil, queue: nil) { _ in received.value += 1 }
+            defer { NotificationCenter.default.removeObserver(token) }
+
+            PreferencesManager.shared.showLineNumbers = true
+            XCTAssertEqual(received.value, 0)
+        }
+    }
+}

--- a/JotTests/LineNumberGutterTests.swift
+++ b/JotTests/LineNumberGutterTests.swift
@@ -393,6 +393,63 @@ final class LineNumberGutterTests: XCTestCase {
         XCTAssertEqual(textView.frame.width, scrollView.contentView.bounds.width)
     }
 
+    // MARK: - Delegate lifecycle (#178)
+    //
+    // NSTextStorage.delegate is assign, not weak. These pin the three
+    // teardown guarantees: an owner clears its slot, a stale gutter
+    // leaves a replacement's slot alone, and deinit backstops the paths
+    // that skip tearDown — the failure modes are a silent freeze and a
+    // use-after-free, neither of which any other test would catch.
+
+    func testTearDownClearsOwnedDelegate() {
+        let (_, textView, gutter) = makeGutter(text: "one\ntwo")
+        XCTAssertTrue(textView.textStorage?.delegate === gutter,
+                      "sanity: the gutter owns the delegate slot after install")
+        gutter.tearDown()
+        XCTAssertNil(textView.textStorage?.delegate)
+    }
+
+    func testStaleTearDownLeavesTheLiveDelegateAlone() {
+        // Install/remove/reinstall is the sequence that bites: if a stale
+        // gutter's tearDown clears a slot a replacement now owns, the
+        // live gutter silently stops receiving edits — line numbers
+        // freeze, nothing crashes, no test fails.
+        let (scrollView, textView, staleGutter) = makeGutter(text: "one\ntwo")
+        let liveGutter = LineNumberGutterView(scrollView: scrollView, textView: textView)
+        scrollView.verticalRulerView = liveGutter
+        XCTAssertTrue(textView.textStorage?.delegate === liveGutter,
+                      "sanity: the replacement claimed the slot on init")
+
+        staleGutter.tearDown()
+        XCTAssertTrue(textView.textStorage?.delegate === liveGutter,
+                      "a stale gutter must not unregister the live one")
+
+        // And the live gutter really is still tracking edits.
+        textView.textStorage?.replaceCharacters(in: NSRange(location: 0, length: 0),
+                                                with: "zero\n")
+        let numbers = liveGutter.lineNumberPositions(in: fullRect(of: textView)).map(\.number)
+        XCTAssertEqual(numbers, [1, 2, 3])
+    }
+
+    func testDeinitClearsTheDelegateWhenTearDownWasSkipped() {
+        // A gutter freed while still registered leaves the storage
+        // pointing at freed memory; the next edit is a use-after-free.
+        // The text view is kept alive across the pool drain so deinit
+        // still has a path to the storage.
+        var keepTextView: NSTextView?
+        weak var deallocatedGutter: LineNumberGutterView?
+        autoreleasepool {
+            let (scrollView, textView, gutter) = makeGutter(text: "one\ntwo")
+            keepTextView = textView
+            deallocatedGutter = gutter
+            scrollView.verticalRulerView = nil
+        }
+        XCTAssertNil(deallocatedGutter,
+                     "sanity: nothing retains the gutter once the ruler slot is cleared")
+        XCTAssertNil(keepTextView?.textStorage?.delegate,
+                     "deinit must clear a delegate slot it still owns")
+    }
+
     // MARK: - Preference (#106)
 
     /// Same save/restore pattern as the font tests; #174 tracks moving

--- a/JotTests/LineNumberGutterTests.swift
+++ b/JotTests/LineNumberGutterTests.swift
@@ -527,6 +527,33 @@ final class LineNumberGutterTests: XCTestCase {
                       "completing layout must invalidate the gutter")
     }
 
+    func testSameLineCaretMovesDoNotRepaintTheGutter() {
+        // Nothing the gutter draws depends on the caret beyond which
+        // number is bold, so a caret move within one line — the
+        // overwhelmingly common selection change — must not repaint;
+        // crossing to another line must. Pinned at the decision method
+        // rather than needsDisplay: in a headless window AppKit's dirty
+        // tracking is unobservable (layerless windows share one dirty
+        // region across siblings, and layer-backed readback is
+        // unreliable), so the observer is detached and the decision
+        // driven directly.
+        let (_, textView, gutter) = makeGutter(text: "one line\nsecond")
+        NotificationCenter.default.removeObserver(gutter)
+
+        textView.setSelectedRange(NSRange(location: 0, length: 0))
+        _ = gutter.noteSelectionChanged()
+
+        textView.setSelectedRange(NSRange(location: 3, length: 0))
+        XCTAssertFalse(gutter.noteSelectionChanged(),
+                       "a caret move within line 1 repaints nothing")
+
+        textView.setSelectedRange(NSRange(location: 10, length: 0))
+        XCTAssertTrue(gutter.noteSelectionChanged(),
+                      "moving the caret to line 2 must rebold the numbers")
+        XCTAssertFalse(gutter.noteSelectionChanged(),
+                       "a second look at the same selection is a no-op")
+    }
+
     // MARK: - Preference (#106)
 
     /// Same save/restore pattern as the font tests; #174 tracks moving

--- a/JotTests/PerformanceTests.swift
+++ b/JotTests/PerformanceTests.swift
@@ -143,6 +143,49 @@ final class PerformanceTests: XCTestCase {
         }
     }
 
+    // MARK: - Line index (#103)
+
+    // The gutter's whole performance argument is that per-frame work is a
+    // binary search over this index instead of an O(document) line scan.
+    // These pin the two costs that argument rests on: the one-time build
+    // and the per-edit incremental update, on a 100k-line document.
+
+    static func manyLinesFixture(_ lines: Int) -> String {
+        return String(repeating: "a line of ordinary text\n", count: lines)
+    }
+
+    func testLineIndexBuildOn100KLines() {
+        let text = Self.manyLinesFixture(100_000) as NSString
+        measure(metrics: [XCTClockMetric(), XCTMemoryMetric()]) {
+            _ = LineIndex(string: text)
+        }
+    }
+
+    func testLineIndexEditNearTheTopOf100KLines() {
+        // Worst case for the incremental update: an edit near the top
+        // shifts every line start after it
+        let text = NSMutableString(string: Self.manyLinesFixture(100_000))
+        var index = LineIndex(string: text)
+        measure(metrics: [XCTClockMetric()]) {
+            text.insert("x", at: 30)
+            index.applyEdit(in: text,
+                            editedRange: NSRange(location: 30, length: 1),
+                            changeInLength: 1)
+        }
+    }
+
+    func testLineNumberLookupsOn100KLines() {
+        let text = Self.manyLinesFixture(100_000) as NSString
+        let index = LineIndex(string: text)
+        let length = text.length
+        measure(metrics: [XCTClockMetric()]) {
+            // A full scroll pass worth of lookups
+            for i in stride(from: 0, to: length, by: max(length / 1000, 1)) {
+                _ = index.lineNumber(forCharacterAt: i)
+            }
+        }
+    }
+
     // MARK: - Fixture sanity
 
     // If a fixture generator drifts (size collapses, syntax stripped), the

--- a/docs/help-notes.md
+++ b/docs/help-notes.md
@@ -21,6 +21,8 @@ Word Count: the bottom, left of each editor window shows the live word count of 
 
 Markdown Preview: selecting `View > Markdown Preview` (or pressing ⌥⌘P) will open Markdown Preview. This parses your file’s content and renders it as HTML. Note: previews do not live-update. 
 
+Line Numbers: each editor window can show line numbers in a gutter along the left edge. The number for the line you’re on is bold. A long line that wraps counts as one line — the gutter numbers your lines, not your window’s rows. Toggle them with `View > Hide Line Numbers` (⇧⌘L) or in Settings; the switch applies to every open window at once.
+
 
 # Markdown Styling Guide
 


### PR DESCRIPTION
Phase 3 of the 1.1.0 plan: the line number gutter, rebuilt from scratch after the old overlay branch failed review, plus the full review-findings cluster and a post-completion three-agent audit.

Closes #42, #101, #102, #103, #104, #105, #106, #107, #108, #109, #178.

(These won't auto-close — this merges to `develop`, not the default branch. Closing manually after merge.)

## What's here

**#42 — the line number gutter itself.** An `NSRulerView` subclass installed as a plain subview (not via `verticalRulerView` — the registration path fights the scroll view's tiling; the file documents why). Line numbers track the editor font at minus 1 pt with a 9 pt floor, the caret's line is marked by bold weight rather than color, and all colors are semantic (`controlBackgroundColor`, `separatorColor`, `secondaryLabelColor`), so Dark Mode and Increase Contrast come free. Toggled from View > Show/Hide Line Numbers (⇧⌘L) or Settings; the preference applies to every open window at once. Default on.

**The audit cluster from the old branch, addressed by design rather than patched:**

- **#101 (overlay breaks with wrap off)** — the clip-view-interception geometry replaces the overlay entirely; `GutterScrollView.tile()` handles both wrap modes and `testTileLeavesWrapOffWidthAlone` pins the wrap-off contract.
- **#102 (off-by-one at a mid-wrapped-line viewport)** — pinned by `testViewportStartingMidWrappedLineNumbersCorrectly`.
- **#103 (O(document) scans per draw, full redraws per keystroke)** — replaced by `LineIndex`, a binary-searched cache of line starts with incremental edit application. Per-keystroke work is bounded to the edited lines; caret moves repaint only the gutter, and only when the line actually changes.
- **#104 (text container width not synced with the inset)** — `tile()` owns the geometry; `testNoPhantomLeftwardScrollRange` and the clip tests cover it.
- **#105 (no number for empty document / trailing empty line)** — pinned by `testEmptyDocumentShowsLineOne` and `testTrailingEmptyLineIsNumbered`.
- **#106 (three unsynced sources of truth)** — collapsed to one: `PreferencesManager.showLineNumbers` broadcasts, and the menu title and Settings popup both follow it. Writing the same value posts nothing (pinned by test).
- **#107 (hardcoded grays regressing #49)** — semantic colors throughout, resolved at draw time; the header comment records the regression so it isn't reintroduced.
- **#108 (coverage)** — 624 lines of tests: the incremental index against a full-rebuild oracle, real `GutterScrollView`/`GutterClipView` geometry, delegate lifecycle, preference plumbing, and performance pins in `PerformanceTests`.
- **#109 (cleanup)** — the old branch's dead code never made it over; this is a fresh implementation.

**#178 — the five-agent review findings**, all addressed across the branch: layout-completion repaints for restored windows, dangling text-storage-delegate paths closed, `tile()` no longer invalidates full-document layout, legacy-scroller clipping, per-caret and per-keystroke work trimmed, the two thickness names untangled, and the delegate conformances isolated to the main actor (SE-0470).

## From the post-completion audit

A second fan-out (code quality, security, accessibility) ran over the finished branch. Highlights:

- Two agents independently fuzzed `LineIndex` with ~20,000 randomized edit sequences each (CRLF, U+2028/U+2029, NEL, surrogate pairs, combining sequences) against a full-rebuild oracle: zero divergences.
- Security timed pathological documents: 5M lines builds the index in ~680 ms with linear memory; a 20M-character single line is fine; no reachable overflow in width math.
- Two fixes landed from the audit: the gutter now opts out of the accessibility hierarchy (it presented as an empty, unlabeled AXRuler to VoiceOver) and owns its `postsBoundsChangedNotifications` flag instead of relying on the styling debounce having set it.
- Security verdict: no findings at any actionable severity. A11y verdict: clean after the one fix; the help content was verified accurate against the actual menu titles and shortcut.

## Testing

273 tests pass, 0 failures. Hand-tested before this PR.

## Filed, not fixed here

#182 (wrap-off text view keeps a stale width when the gutter toggles), #183 (no test drives the gutter scroll-repaint observer), #184 (seeded-random differential fuzz for `LineIndex` as a repo-resident test), and a note on #174 (the gutter suite inherits the `UserDefaults` pollution).

One watch item, not an issue: the clip-view `tile()` interception leans on undocumented AppKit behavior — worth a re-check on each macOS beta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PGnv8V4CEx4A493DFBKgve
