### PR TITLE
fix: restore green CI — recovery announcement tripped Xcode 26 strict concurrency

### DIFF
--- a/Jot/App/Document.swift
+++ b/Jot/App/Document.swift
@@ -288,22 +288,15 @@ class Document: NSDocument {
 			? "Recovered 1 unsaved draft from a previous session"
 			: "Recovered \(count) unsaved drafts from a previous session"
 
-		let post = {
-			NSAccessibility.post(
-				element: window,
-				notification: .announcementRequested,
-				userInfo: [
-					.announcement: message,
-					.priority: NSAccessibilityPriorityLevel.high.rawValue
-				]
-			)
-		}
-
 		if NSApp.isActive {
-			post()
+			postAnnouncement(message, to: window)
 			return
 		}
-		// Launch case: wait for activation, then post once
+		// Launch case: wait for activation, then post once. The observer
+		// crosses an isolation boundary, so it may only capture Sendable
+		// values — the window travels as its number and is looked up
+		// again on the main actor, not captured.
+		let windowNumber = window.windowNumber
 		var token: NSObjectProtocol?
 		token = NotificationCenter.default.addObserver(
 			forName: NSApplication.didBecomeActiveNotification,
@@ -311,7 +304,23 @@ class Document: NSDocument {
 			queue: .main
 		) { _ in
 			if let token { NotificationCenter.default.removeObserver(token) }
-			MainActor.assumeIsolated { post() }
+			MainActor.assumeIsolated {
+				// The window may have closed during launch; drop the
+				// announcement rather than target a dead element.
+				guard let window = NSApp.window(withWindowNumber: windowNumber) else { return }
+				postAnnouncement(message, to: window)
+			}
 		}
+	}
+
+	private static func postAnnouncement(_ message: String, to window: NSWindow) {
+		NSAccessibility.post(
+			element: window,
+			notification: .announcementRequested,
+			userInfo: [
+				.announcement: message,
+				.priority: NSAccessibilityPriorityLevel.high.rawValue
+			]
+		)
 	}
 }


### PR DESCRIPTION
CI has been red since the Phase 2 merge (2026-08-09): every Build and Test and CodeQL run on develop and both phase PRs failed on one error —

```
Jot/App/Document.swift:314:36: error: sending 'post' risks causing data races
```

The recovered-draft VoiceOver announcement (from #153, PR #177) built a closure capturing the target NSWindow, then handed it into the `didBecomeActiveNotification` observer. The runner's Xcode 26.6 compiler rejects sending that non-Sendable closure across the isolation boundary; local toolchains on macOS 15 accept it, which is why 273 tests pass locally on both sides of this change and the break only shows in CI.

The fix restructures rather than suppresses: the observer now captures only Sendable values (the message string and the window *number*), re-resolves the window via `NSApp.window(withWindowNumber:)` inside `MainActor.assumeIsolated`, and drops the announcement if the window closed during launch — previously it would have targeted a dead window anyway. No `nonisolated(unsafe)`, no `@preconcurrency`.

Behavior is unchanged on the happy path: active app posts immediately; launch case posts once on activation, high priority, targeted at the recovered window.

## Testing

273 tests pass locally. The error itself is not reproducible on a macOS 15 toolchain — this PR's CI run is the real verification, so it should not merge until checks are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PGnv8V4CEx4A493DFBKgve