### PR TITLE
feat: add window tabbing menu items

### DIFF
--- a/Jot/Resources/Base.lproj/Main.storyboard
+++ b/Jot/Resources/Base.lproj/Main.storyboard
@@ -688,6 +688,31 @@
                                                 <action selector="arrangeInFront:" target="Ady-hI-5gd" id="DRN-fu-gQh"/>
                                             </connections>
                                         </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="sep-tab-001"/>
+                                        <menuItem title="Show Previous Tab" keyEquivalent="{" id="tab-prev-01">
+                                            <modifierMask key="keyEquivalentModifierMask" shift="YES" command="YES"/>
+                                            <connections>
+                                                <action selector="selectPreviousTab:" target="Ady-hI-5gd" id="tab-prev-c1"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Show Next Tab" keyEquivalent="}" id="tab-next-01">
+                                            <modifierMask key="keyEquivalentModifierMask" shift="YES" command="YES"/>
+                                            <connections>
+                                                <action selector="selectNextTab:" target="Ady-hI-5gd" id="tab-next-c1"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Move Tab to New Window" id="tab-move-01">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="moveTabToNewWindow:" target="Ady-hI-5gd" id="tab-move-c1"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Merge All Windows" id="tab-merg-01">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="mergeAllWindows:" target="Ady-hI-5gd" id="tab-merg-c1"/>
+                                            </connections>
+                                        </menuItem>
                                     </items>
                                 </menu>
                             </menuItem>


### PR DESCRIPTION
## Summary
- Add Show Previous Tab, Show Next Tab, Move Tab to New Window, and Merge All Windows to the Window menu
- Stock NSWindow selectors that auto-validate (disabled when no tabs exist)

Closes #189

## Test plan
- [x] Window menu shows new tab items
- [x] Items are disabled when only one window/tab is open
- [x] Items work correctly with multiple tabbed windows

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PGnv8V4CEx4A493DFBKgve