### PR TITLE
feat: remember window position and size across launches

### DIFF
--- a/Jot/Resources/Base.lproj/Main.storyboard
+++ b/Jot/Resources/Base.lproj/Main.storyboard
@@ -744,7 +744,7 @@
         <scene sceneID="R2V-B0-nI4">
             <objects>
                 <windowController storyboardIdentifier="Document Window Controller" id="jGA-0Y-lOj" sceneMemberID="viewController">
-                    <window key="window" title="Window" allowsToolTipsWhenApplicationIsInactive="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" id="Ckk-yw-fiv">
+                    <window key="window" title="Window" allowsToolTipsWhenApplicationIsInactive="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="DocumentWindow" animationBehavior="default" id="Ckk-yw-fiv">
                         <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
                         <rect key="contentRect" x="196" y="240" width="480" height="300"/>
                         <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1027"/>


### PR DESCRIPTION
## Summary
- Add frameAutosaveName to the document window so new windows open at the last-used size and position

Closes #187

## Test plan
- [ ] Resize a window, quit, relaunch -- new window opens at the saved size/position
- [ ] Multiple windows still open correctly

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PGnv8V4CEx4A493DFBKgve