### PR TITLE
feat: enable continuous spell-checking by default

### DIFF
--- a/Jot/Editor/EditorViewController.swift
+++ b/Jot/Editor/EditorViewController.swift
@@ -41,6 +41,7 @@ class EditorViewController: NSViewController, NSTextViewDelegate {
 	override func viewDidLoad() {
 		super.viewDidLoad()
 		textView.delegate = self
+		textView.isContinuousSpellCheckingEnabled = true
 		setupWordCountToggle()
 		loadFontPreferences()
 		updateWordCount()


### PR DESCRIPTION
## Summary
- Enable continuous spell-checking by default in the editor
- Still togglable per-window via Edit > Spelling and Grammar

Closes #192

## Test plan
- [x] New windows show spell-check squiggles under misspelled words
- [x] Toggling off via Edit > Spelling and Grammar works per-window

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PGnv8V4CEx4A493DFBKgve