### PR TITLE
chore: migrate from string UTI identifiers to UTType constants

### DIFF
--- a/Jot/Editor/EditorTextView.swift
+++ b/Jot/Editor/EditorTextView.swift
@@ -14,10 +14,10 @@ import UniformTypeIdentifiers
 class EditorTextView: NSTextView {
 
     // UTIs the app can open, matching Info.plist declarations.
-    private static let supportedTypeIdentifiers: [String] = [
-        "public.plain-text",
-        "net.daringfireball.markdown",
-        "public.source-code",
+    private static let supportedTypes: [UTType] = [
+        .plainText,
+        UTType("net.daringfireball.markdown")!,
+        .sourceCode,
     ]
 
     override func draggingEntered(_ sender: NSDraggingInfo) -> NSDragOperation {
@@ -135,10 +135,7 @@ class EditorTextView: NSTextView {
 
     private static func isSupportedUTI(_ uti: String) -> Bool {
         guard let type = UTType(uti) else { return false }
-        return supportedTypeIdentifiers.contains { identifier in
-            guard let supported = UTType(identifier) else { return false }
-            return type.conforms(to: supported)
-        }
+        return supportedTypes.contains { type.conforms(to: $0) }
     }
 
     private func utiForURL(_ url: URL) -> String? {


### PR DESCRIPTION
## Summary
- Replace string-based UTI array with UTType constants (.plainText, .sourceCode)
- Simplify the conformance check in isSupportedUTI

Closes #197

## Test plan
- [x] Drag-and-drop of .txt and .md files onto the editor still works
- [x] Drag-and-drop of unsupported file types is still rejected

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PGnv8V4CEx4A493DFBKgve