### PR TITLE
fix(a11y): add lang and title to help pages (#176)

### DIFF
--- a/Jot/Resources/index.html
+++ b/Jot/Resources/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>Help</title>
 	<meta charset="utf-8">

--- a/Jot/Windows/HelpViewController.swift
+++ b/Jot/Windows/HelpViewController.swift
@@ -25,15 +25,16 @@ class HelpViewController: NSViewController, WKNavigationDelegate {
 			assertionFailure("Help resource \(fileName).html is missing from the bundle")
 			webView.loadHTMLString("""
 				<!DOCTYPE html>
-				<html>
+				<html lang="en">
 				<head>
 				<meta charset="utf-8">
 				<meta name="color-scheme" content="light dark">
+				<title>Jot Help</title>
 				</head>
-				<body style="font-family: -apple-system; margin: 2em;">
+				<body style="font-family: -apple-system, system-ui; margin: 2em;">
 				<h1>Help unavailable</h1>
 				<p>The help content could not be loaded. Please
-				<a href="mailto:brian.goodwin@protonmail.com">email the developer</a>
+				<a href="https://github.com/brianjgoodwin/Jot/wiki/Feedback-and-Support">contact support</a>
 				to report this.</p>
 				</body>
 				</html>


### PR DESCRIPTION
## Summary
- Add `lang="en"` to bundled and fallback help HTML so VoiceOver picks the correct speech synthesizer
- Add `<title>Jot Help</title>` to the fallback error page
- Replace hardcoded email with GitHub wiki support link in fallback HTML
- Add `system-ui` font fallback in the fallback page

Closes #176

## Test plan
- [ ] Open Help window, verify VoiceOver reads content with English synthesizer
- [ ] Verify fallback HTML renders correctly (temporarily break bundle path to trigger it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PGnv8V4CEx4A493DFBKgve