### PR TITLE
fix: open external help links in default browser (#100)

### DIFF
--- a/Jot/Resources/index.html
+++ b/Jot/Resources/index.html
@@ -93,7 +93,7 @@
 			<p>Markdown is intended to be as easy-to-read and easy-to-write as is feasible.</p>
 			<p>Readability, however, is emphasized above all else. A Markdown-formatted document should be publishable as-is, as plain text, without looking like it&rsquo;s been marked up with tags or formatting instructions.</p>
 		</blockquote>
-		<p>&mdash; <a href="https://daringfireball.net/projects/markdown/syntax">John Gruber</a></p>
+		<p>&mdash; <a href="https://daringfireball.net/projects/markdown/syntax" target="_blank">John Gruber</a></p>
 		<p>Jot - Text Editor uses its own, custom engine for markdown syntax highlighting. It&rsquo;s lightweight and fast. It doesn&rsquo;t support every possible edge case. This is for jotting down meeting notes.</p>
 
 		<h3>Headers</h3>
@@ -192,7 +192,7 @@ console.log('Hello, world!');
 
 	<section id="feedback-support">
 		<h2>Feedback</h2>
-		<p>If you have feedback, you can <a href="mailto:brian.goodwin@protonmail.com">email the developer</a>. This is a free project and a labor of love, so we appreciate your understanding and patience.</p>
+		<p>If you have feedback, you can <a href="mailto:brian.goodwin@protonmail.com" target="_blank">email the developer</a>. This is a free project and a labor of love, so we appreciate your understanding and patience.</p>
 	</section>
 </body>
 </html>

--- a/Jot/Windows/HelpViewController.swift
+++ b/Jot/Windows/HelpViewController.swift
@@ -8,12 +8,13 @@
 import Cocoa
 import WebKit
 
-class HelpViewController: NSViewController, WKNavigationDelegate {
+class HelpViewController: NSViewController, WKNavigationDelegate, WKUIDelegate {
 	@IBOutlet var webView: WKWebView!
 
 	override func viewDidLoad() {
 		super.viewDidLoad()
 		webView.navigationDelegate = self
+		webView.uiDelegate = self
 		webView.setAccessibilityLabel("Help content")
 		loadHelpFile(named: "index")
 	}
@@ -43,6 +44,16 @@ class HelpViewController: NSViewController, WKNavigationDelegate {
 
 		let fileURL = URL(fileURLWithPath: filePath)
 		webView.loadFileURL(fileURL, allowingReadAccessTo: fileURL.deletingLastPathComponent())
+	}
+
+	func webView(_ webView: WKWebView, createWebViewWith configuration: WKWebViewConfiguration, for navigationAction: WKNavigationAction, windowFeatures: WKWindowFeatures) -> WKWebView? {
+		if let url = navigationAction.request.url {
+			let scheme = url.scheme?.lowercased() ?? ""
+			if scheme == "http" || scheme == "https" || scheme == "mailto" {
+				NSWorkspace.shared.open(url)
+			}
+		}
+		return nil
 	}
 
 	func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {


### PR DESCRIPTION
## Summary
- Add `target="_blank"` to external links in help HTML (Gruber link, mailto)
- Implement `WKUIDelegate.createWebViewWith` to intercept `target="_blank"` navigations
- Allowlist http/https/mailto schemes before opening via `NSWorkspace`
- Return `nil` to prevent WKWebView from creating a new web view

Closes #100

## Test plan
- [ ] Click "John Gruber" link in help window -- opens in Safari
- [ ] Click "email the developer" link -- opens in Mail (or default mail client)
- [ ] Verify in-page anchor links (table of contents) still work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PGnv8V4CEx4A493DFBKgve