### PR TITLE
fix: harden help navigation policy with scheme allowlist (#113)

### DIFF
--- a/Jot/Resources/index.html
+++ b/Jot/Resources/index.html
@@ -93,7 +93,7 @@
 			<p>Markdown is intended to be as easy-to-read and easy-to-write as is feasible.</p>
 			<p>Readability, however, is emphasized above all else. A Markdown-formatted document should be publishable as-is, as plain text, without looking like it&rsquo;s been marked up with tags or formatting instructions.</p>
 		</blockquote>
-		<p>&mdash; <a href="https://daringfireball.net/projects/markdown/syntax">John Gruber</a></p>
+		<p>&mdash; <a href="https://daringfireball.net/projects/markdown/syntax" target="_blank">John Gruber</a></p>
 		<p>Jot - Text Editor uses its own, custom engine for markdown syntax highlighting. It&rsquo;s lightweight and fast. It doesn&rsquo;t support every possible edge case. This is for jotting down meeting notes.</p>
 
 		<h3>Headers</h3>
@@ -192,7 +192,7 @@ console.log('Hello, world!');
 
 	<section id="feedback-support">
 		<h2>Feedback</h2>
-		<p>If you have feedback, you can <a href="mailto:brian.goodwin@protonmail.com">email the developer</a>. This is a free project and a labor of love, so we appreciate your understanding and patience.</p>
+		<p>If you have feedback, you can <a href="mailto:brian.goodwin@protonmail.com" target="_blank">email the developer</a>. This is a free project and a labor of love, so we appreciate your understanding and patience.</p>
 	</section>
 </body>
 </html>

--- a/Jot/Windows/HelpViewController.swift
+++ b/Jot/Windows/HelpViewController.swift
@@ -8,12 +8,13 @@
 import Cocoa
 import WebKit
 
-class HelpViewController: NSViewController, WKNavigationDelegate {
+class HelpViewController: NSViewController, WKNavigationDelegate, WKUIDelegate {
 	@IBOutlet var webView: WKWebView!
 
 	override func viewDidLoad() {
 		super.viewDidLoad()
 		webView.navigationDelegate = self
+		webView.uiDelegate = self
 		webView.setAccessibilityLabel("Help content")
 		loadHelpFile(named: "index")
 	}
@@ -43,6 +44,16 @@ class HelpViewController: NSViewController, WKNavigationDelegate {
 
 		let fileURL = URL(fileURLWithPath: filePath)
 		webView.loadFileURL(fileURL, allowingReadAccessTo: fileURL.deletingLastPathComponent())
+	}
+
+	func webView(_ webView: WKWebView, createWebViewWith configuration: WKWebViewConfiguration, for navigationAction: WKNavigationAction, windowFeatures: WKWindowFeatures) -> WKWebView? {
+		if let url = navigationAction.request.url {
+			let scheme = url.scheme?.lowercased() ?? ""
+			if scheme == "http" || scheme == "https" || scheme == "mailto" {
+				NSWorkspace.shared.open(url)
+			}
+		}
+		return nil
 	}
 
 	func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {

--- a/Jot/Windows/HelpViewController.swift
+++ b/Jot/Windows/HelpViewController.swift
@@ -58,19 +58,20 @@ class HelpViewController: NSViewController, WKNavigationDelegate, WKUIDelegate {
 
 	func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
 		guard let url = navigationAction.request.url else {
-			decisionHandler(.allow)
+			decisionHandler(.cancel)
 			return
 		}
 
-		// Allow file:// navigation for local help pages
 		if url.scheme == "file" {
 			decisionHandler(.allow)
 			return
 		}
 
-		// Open all non-file links (http, https, mailto, etc.) in the default app
 		if navigationAction.navigationType == .linkActivated {
-			NSWorkspace.shared.open(url)
+			let scheme = url.scheme?.lowercased() ?? ""
+			if scheme == "http" || scheme == "https" || scheme == "mailto" {
+				NSWorkspace.shared.open(url)
+			}
 		}
 		decisionHandler(.cancel)
 	}


### PR DESCRIPTION
## Summary
- Deny nil-URL navigations by default (fail-closed instead of fail-open)
- Allowlist http, https, and mailto schemes before opening externally via NSWorkspace
- Non-allowlisted schemes are silently cancelled instead of passed to the system

Depends on #206

Closes #113

## Test plan
- [x] Help window loads normally
- [x] In-page anchor links (table of contents) work
- [x] External links open in default browser (after #206 merges)
- [x] Verify no unexpected scheme handlers can be triggered

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PGnv8V4CEx4A493DFBKgve
