### PR TITLE
fix: wire Cmd+? to help window via showHelp: (#114)

### DIFF
--- a/Jot/App/AppDelegate.swift
+++ b/Jot/App/AppDelegate.swift
@@ -24,7 +24,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
 		aboutWindowController?.showWindow(sender)
 	}
 
-	@IBAction func showHelpWindow(_ sender: Any) {
+	@IBAction func showHelp(_ sender: Any?) {
 		if helpWindowController == nil {
 			let storyboard = NSStoryboard(name: "Main", bundle: nil)
 			helpWindowController = storyboard.instantiateController(withIdentifier: "HelpWindowController") as? HelpWindowController

--- a/Jot/Resources/Base.lproj/Main.storyboard
+++ b/Jot/Resources/Base.lproj/Main.storyboard
@@ -698,7 +698,7 @@
                                         <menuItem title="Jot Help" id="vKt-3m-hiG">
                                             <modifierMask key="keyEquivalentModifierMask"/>
                                             <connections>
-                                                <action selector="showHelpWindow:" target="Voe-Tx-rLC" id="Q9S-f0-RA8"/>
+                                                <action selector="showHelp:" target="Ady-hI-5gd" id="Q9S-f0-RA8"/>
                                             </connections>
                                         </menuItem>
                                         <menuItem isSeparatorItem="YES" id="3Sp-Ai-kYz"/>


### PR DESCRIPTION
## Summary
- Rewire "Jot Help" menu item from custom `showHelpWindow:` to standard `showHelp:` on First Responder
- Rename AppDelegate method to `showHelp(_:)` to match the selector
- macOS automatically assigns Cmd+? to the first item in a `systemMenu="help"` menu targeting `showHelp:`

Closes #114

## Test plan
- [x] Cmd+? opens the help window
- [x] Help > Jot Help menu item shows Cmd+? shortcut
- [x] Help menu search field still appears

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PGnv8V4CEx4A493DFBKgve
