### PR TITLE
fix(a11y): support Cmd+/Cmd- zoom in help window (#115)

### DIFF
--- a/Jot/Windows/HelpViewController.swift
+++ b/Jot/Windows/HelpViewController.swift
@@ -45,6 +45,18 @@ class HelpViewController: NSViewController, WKNavigationDelegate {
 		webView.loadFileURL(fileURL, allowingReadAccessTo: fileURL.deletingLastPathComponent())
 	}
 
+	@IBAction func increaseFontSize(_ sender: Any?) {
+		webView.pageZoom *= 1.1
+	}
+
+	@IBAction func decreaseFontSize(_ sender: Any?) {
+		webView.pageZoom /= 1.1
+	}
+
+	@IBAction func resetFontSize(_ sender: Any?) {
+		webView.pageZoom = 1.0
+	}
+
 	func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
 		guard let url = navigationAction.request.url else {
 			decisionHandler(.allow)


### PR DESCRIPTION
## Summary
- Add `increaseFontSize`/`decreaseFontSize`/`resetFontSize` actions to HelpViewController
- Existing Bigger (Cmd+) / Smaller (Cmd-) / Actual Size (Cmd+0) menu items now work when the help window is key
- Uses `webView.pageZoom` with 1.1x steps matching typical browser behavior

Closes #115

## Test plan
- [x] Open help window, Cmd+ zooms in
- [x] Cmd- zooms out
- [x] Cmd+0 resets to default size
- [x] Editor font sizing still works when a document window is key

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PGnv8V4CEx4A493DFBKgve
