### PR TITLE
chore(help): apply help polish bundle (#117)

### DIFF
--- a/Jot.xcodeproj/project.pbxproj
+++ b/Jot.xcodeproj/project.pbxproj
@@ -37,7 +37,7 @@
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		D309045D301E4AE000F75C56 /* JotTests */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = JotTests; sourceTree = "<group>"; };
-		D3AA9EDE302633A300665C2D /* Jot */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (D3AA9EF5302633A300665C2D /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = Jot; sourceTree = "<group>"; };
+		D3AA9EDE302633A300665C2D /* Jot */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (D3AA9EF5302633A300665C2D /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (Resources/Help, ); path = Jot; sourceTree = "<group>"; };
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */

--- a/Jot/Resources/Help/Help.html
+++ b/Jot/Resources/Help/Help.html
@@ -3,24 +3,18 @@
 <head>
 	<title>Help</title>
 	<meta charset="utf-8">
+	<meta name="color-scheme" content="light dark">
 
 	<style>
+		:root {
+			color-scheme: light dark;
+		}
 		body {
 			margin: 2em;
-			color: #333333;
-			background-color: white;
+			color: CanvasText;
+			background-color: Canvas;
 			line-height: 1.4em;
 			font-family: -apple-system;
-		}
-		@media (prefers-color-scheme: dark) {
-			body {
-				color: white;
-				background-color: #000000;
-			}
-
-			table tr:nth-child(odd) {
-				background-color: #1E1E1E !important;
-			}
 		}
 		table {
 			width: 100%;
@@ -29,7 +23,7 @@
 			margin-top: 1.0em;
 		}
 		table tr:nth-child(odd) {
-			background-color: #F0F0F0;
+			background-color: rgba(128, 128, 128, 0.15);
 		}
 		table tr td:first-child {
 			width: 60%;
@@ -84,6 +78,7 @@
 
 		<h3>Line Numbers</h3>
 		<p>Each editor window can show line numbers in a gutter along the left edge. The number for the line you&rsquo;re on is bold. A long line that wraps counts as one line &mdash; the gutter numbers your lines, not your window&rsquo;s rows. Toggle them with <code>View &gt; Hide Line Numbers</code> (<kbd>&#8679;&#8984;L</kbd>) or in Settings; the switch applies to every open window at once.</p>
+
 	</section>
 
 	<section id="markdown-guide">

--- a/Jot/Windows/HelpViewController.swift
+++ b/Jot/Windows/HelpViewController.swift
@@ -16,14 +16,17 @@ class HelpViewController: NSViewController, WKNavigationDelegate, WKUIDelegate {
 		webView.navigationDelegate = self
 		webView.uiDelegate = self
 		webView.setAccessibilityLabel("Help content")
-		loadHelpFile(named: "index")
+		// Match the window chrome so dark mode doesn't flash white
+		// before the page's CSS paints (#117)
+		webView.underPageBackgroundColor = .windowBackgroundColor
+		loadHelpFile()
 	}
 
-	func loadHelpFile(named fileName: String) {
-		guard let filePath = Bundle.main.path(forResource: fileName, ofType: "html") else {
+	func loadHelpFile() {
+		guard let fileURL = Bundle.main.url(forResource: "Help", withExtension: "html", subdirectory: "Help") else {
 			// A build-phase mistake (target membership, a rename) would
 			// otherwise ship as a silently blank window (#116)
-			assertionFailure("Help resource \(fileName).html is missing from the bundle")
+			assertionFailure("Help/Help.html is missing from the bundle")
 			webView.loadHTMLString("""
 				<!DOCTYPE html>
 				<html lang="en">
@@ -43,7 +46,7 @@ class HelpViewController: NSViewController, WKNavigationDelegate, WKUIDelegate {
 			return
 		}
 
-		let fileURL = URL(fileURLWithPath: filePath)
+		// Scope read access to the Help folder only, not all of Resources
 		webView.loadFileURL(fileURL, allowingReadAccessTo: fileURL.deletingLastPathComponent())
 	}
 


### PR DESCRIPTION
## Summary

Applies the still-relevant items from the #117 help polish bundle:

- **Item 5 — system colors**: replaces the hand-copied hex palette with CSS system colors (`Canvas`/`CanvasText`) plus a `color-scheme: light dark` declaration, and collapses the two table-stripe colors into one translucent gray. The dark-mode media query and its `!important` override are gone.
- **Item 7 — dark-mode flash**: sets `webView.underPageBackgroundColor = .windowBackgroundColor` so the help window no longer flashes white in dark mode before the page CSS paints.
- **Item 8 — Help folder**: moves `Resources/index.html` to a `Resources/Help/Help.html` folder reference (`explicitFolders` in the synchronized root group), narrowing `allowingReadAccessTo` from the whole Resources root to just the help assets and making room for future screenshots.

## Not included, and why

- **Items 4, 6, 9 are moot**: they audited the pre-rewrite help page that PR #168 replaced (dead `hr` CSS, feature cards, the old `createWebViewWith` shape).
- **Item 2**: Paste and Match Style and Tab/⇧Tab were already documented by the rewrite; the remaining omissions (⌘R, ⌘E, ⌘J) were considered and deliberately left undocumented to keep the help focused.
- **Items 1 and 3**: dropped per discussion (item 1 tracked separately; item 3 no longer applies).
- **Item 10**: split out as #211 — a storyboard-vs-help shortcut drift test under the Test Infrastructure milestone.

Closes #117.

## Testing

- Local build verified: bundle contains `Resources/Help/Help.html` as a real folder, no stray `index.html`.
- Full unit test suite passes (273 tests) after rebasing onto develop with #209/#210 merged.
- Manually verified light/dark appearance of the help window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015SvAwERh6dke6vSFmjNXVg
