### PR TITLE
feat: switch to modern find bar with regex and match-case support (#179)

### DIFF
--- a/Jot/Editor/EditorViewController.swift
+++ b/Jot/Editor/EditorViewController.swift
@@ -42,6 +42,7 @@ class EditorViewController: NSViewController, NSTextViewDelegate {
 		super.viewDidLoad()
 		textView.delegate = self
 		textView.isContinuousSpellCheckingEnabled = true
+		textView.isIncrementalSearchingEnabled = true
 		setupWordCountToggle()
 		loadFontPreferences()
 		updateWordCount()
@@ -269,7 +270,7 @@ class EditorViewController: NSViewController, NSTextViewDelegate {
 		// API makes the clip view report a phantom leftward scroll range
 		// that rubber-bands (#178). See the geometry note in
 		// LineNumberGutter.swift before "improving" this.
-		scrollView.addSubview(gutter)
+		scrollView.addSubview(gutter, positioned: .below, relativeTo: nil)
 		scrollView.gutterView = gutter
 		lineNumberGutter = gutter
 		// Geometry is owned by GutterScrollView.tile(), which reserves the

--- a/Jot/Resources/Base.lproj/Main.storyboard
+++ b/Jot/Resources/Base.lproj/Main.storyboard
@@ -788,7 +788,7 @@
                                     <rect key="frame" x="0.0" y="0.0" width="480" height="269"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
-                                        <textView wantsLayer="YES" importsGraphics="NO" richText="NO" verticallyResizable="YES" findStyle="panel" allowsUndo="YES" smartInsertDelete="YES" id="gj9-0m-evT" customClass="EditorTextView" customModule="Jot" customModuleProvider="target">
+                                        <textView wantsLayer="YES" importsGraphics="NO" richText="NO" verticallyResizable="YES" findStyle="bar" allowsUndo="YES" smartInsertDelete="YES" id="gj9-0m-evT" customClass="EditorTextView" customModule="Jot" customModuleProvider="target">
                                             <rect key="frame" x="0.0" y="0.0" width="480" height="269"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>


### PR DESCRIPTION
## Summary

Switches the editor from the pre-10.7 floating Find panel to the modern embedded find bar:

- `findStyle="panel"` → `findStyle="bar"` in `Main.storyboard`
- `textView.isIncrementalSearchingEnabled = true` for live match highlighting
- Gutter is added `positioned: .below` so the find bar overlays it correctly

This unlocks regex search, the match-case toggle, and incremental highlighting for free via `NSTextFinder`. Existing Find menu wiring (`performFindPanelAction:` with standard tags) is unchanged.

## Rebase note

Rebased onto current develop; one trivial conflict in `EditorViewController.viewDidLoad` (spell-checking default from #192 landed on the same line region) resolved by keeping both lines. Full unit suite passes locally (273 tests).

## Before merging

Please give the find bar a visual once-over with the line-number gutter enabled (open Find, scroll, resize) — the issue flagged this interaction as the thing to verify by eye.

Closes #179.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015SvAwERh6dke6vSFmjNXVg
