### PR TITLE
fix: match WKNavigationDelegate signatures to the current SDK (#208)

### DIFF
--- a/Jot/Markdown/MarkdownPreviewViewController.swift
+++ b/Jot/Markdown/MarkdownPreviewViewController.swift
@@ -10,7 +10,7 @@ import Down
 import WebKit
 import os.signpost
 
-class MarkdownPreviewViewController: NSViewController, @preconcurrency WKNavigationDelegate {
+class MarkdownPreviewViewController: NSViewController, WKNavigationDelegate {
 
 	@IBOutlet weak var webView: WKWebView!
 
@@ -23,7 +23,7 @@ class MarkdownPreviewViewController: NSViewController, @preconcurrency WKNavigat
 	// Block all link navigation to prevent crafted markdown from navigating
 	// the preview to a remote URL. Clicked links open in the default browser.
 	func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction,
-				 decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+				 decisionHandler: @escaping @MainActor (WKNavigationActionPolicy) -> Void) {
 		// Allow programmatic loads (loadHTMLString) -- these use .other
 		guard navigationAction.navigationType == .linkActivated else {
 			decisionHandler(.allow)

--- a/Jot/Windows/HelpViewController.swift
+++ b/Jot/Windows/HelpViewController.swift
@@ -62,7 +62,7 @@ class HelpViewController: NSViewController, WKNavigationDelegate, WKUIDelegate {
 		webView.pageZoom = 1.0
 	}
 
-	func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+	func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping @MainActor (WKNavigationActionPolicy) -> Void) {
 		guard let url = navigationAction.request.url else {
 			decisionHandler(.cancel)
 			return


### PR DESCRIPTION
## Summary

Fixes the two "nearly matches optional requirement" warnings by matching the `webView(_:decidePolicyFor:decisionHandler:)` signatures to the current SDK — the decision handler parameter needs `@MainActor`. Without it, the methods only satisfy `WKNavigationDelegate` through Objective-C runtime matching and could silently stop being called under a future SDK.

Also removes the no-op `@preconcurrency` from `MarkdownPreviewViewController`'s conformance.

## Verification

- Build log confirms zero "nearly matches" warnings after the change (two before).
- Full unit suite passes locally (273 tests).
- Behavior unchanged: help-window link policy and preview link-blocking both go through these methods; no logic was touched.

Closes #208.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015SvAwERh6dke6vSFmjNXVg
