### PR TITLE
feat: preserve file encoding and line endings (#194, #195)

### DIFF
--- a/Jot/App/Document.swift
+++ b/Jot/App/Document.swift
@@ -105,10 +105,12 @@ class Document: NSDocument {
 		}
 		var decoded = rawDecoded
 		readEncoding = encoding
-		// String(data:encoding:.utf8) keeps a byte-order mark as U+FEFF:
-		// invisible in the editor, but present in counts, searches, and
-		// position math. Strip it here; save puts the bytes back (#194).
-		hadUTF8BOM = encoding == .utf8 && decoded.hasPrefix("\u{FEFF}")
+		// A UTF-8 byte-order mark must not leak into the editor buffer:
+		// older Foundation keeps it as an invisible U+FEFF that pollutes
+		// counts and searches, newer Foundation strips it during decoding.
+		// Detecting from the raw bytes works on both; save puts the bytes
+		// back either way (#194).
+		hadUTF8BOM = encoding == .utf8 && data.starts(with: [0xEF, 0xBB, 0xBF])
 		if decoded.hasPrefix("\u{FEFF}") {
 			decoded.removeFirst()
 		}

--- a/Jot/App/Document.swift
+++ b/Jot/App/Document.swift
@@ -15,6 +15,23 @@ class Document: NSDocument {
 	// through the main thread in practice.
 	nonisolated(unsafe) var text = ""
 
+	// MARK: - File encoding and line endings (#194, #195)
+	// Same main-thread serialization argument as `text` above.
+
+	/// The encoding the file was read with; saves go back out the same way
+	/// instead of silently converting to UTF-8. Untitled documents are UTF-8.
+	nonisolated(unsafe) var readEncoding: String.Encoding = .utf8
+	/// A UTF-8 byte-order mark is stripped from the buffer on read and put
+	/// back on save; files without one never gain one.
+	nonisolated(unsafe) var hadUTF8BOM = false
+	/// The buffer is normalized to LF; this convention is restored on save.
+	nonisolated(unsafe) var lineEnding: LineEnding = .lf
+
+	/// Encoding parsed from the file's com.apple.TextEncoding extended
+	/// attribute, alive only while a URL-based read is in flight — the
+	/// data-based read consults it for its first decoding attempt.
+	private var xattrEncodingHint: String.Encoding?
+
 	// Unconditionally true: NSDocument owns autosave, crash recovery
 	// (drafts in ~/Library/Autosave Information), and the Versions
 	// browser. The user-toggleable preference and the hand-rolled
@@ -59,18 +76,55 @@ class Document: NSDocument {
 		// `text` is nonisolated(unsafe); catch any future off-main caller
 		dispatchPrecondition(condition: .onQueue(.main))
 		syncTextFromEditor()
-		guard let data = text.data(using: .utf8) else {
-			throw NSError(domain: NSOSStatusErrorDomain, code: unimpErr, userInfo: nil)
+		var outgoing = lineEnding.restore(in: text)
+		if hadUTF8BOM {
+			outgoing = "\u{FEFF}" + outgoing
+		}
+		guard let data = outgoing.data(using: readEncoding) else {
+			// The user typed characters the original encoding can't hold
+			// (a CP1252 file gaining an emoji). Never convert silently —
+			// the error offers the conversion as an explicit choice (#194)
+			throw encodingUnrepresentableError()
 		}
 		return data
 	}
 
+	override func read(from url: URL, ofType typeName: String) throws {
+		// Peek at the com.apple.TextEncoding attribute before the default
+		// implementation funnels down to read(from:ofType:) with bare data
+		xattrEncodingHint = Self.encodingFromExtendedAttribute(at: url)
+		defer { xattrEncodingHint = nil }
+		try super.read(from: url, ofType: typeName)
+	}
+
 	override func read(from data: Data, ofType typeName: String) throws {
 		dispatchPrecondition(condition: .onQueue(.main))
-		// Try UTF-8 first
-		if let loadedText = String(data: data, encoding: .utf8) {
-			text = loadedText
-			return
+		guard let (rawDecoded, encoding) = Self.decode(data, hint: xattrEncodingHint) else {
+			throw NSError(domain: NSOSStatusErrorDomain, code: unimpErr,
+						  userInfo: [NSLocalizedDescriptionKey: "Unable to read file: unsupported text encoding"])
+		}
+		var decoded = rawDecoded
+		readEncoding = encoding
+		// String(data:encoding:.utf8) keeps a byte-order mark as U+FEFF:
+		// invisible in the editor, but present in counts, searches, and
+		// position math. Strip it here; save puts the bytes back (#194).
+		hadUTF8BOM = encoding == .utf8 && decoded.hasPrefix("\u{FEFF}")
+		if decoded.hasPrefix("\u{FEFF}") {
+			decoded.removeFirst()
+		}
+		lineEnding = LineEnding.detect(in: decoded) ?? .lf
+		text = LineEnding.normalizeToLF(decoded)
+	}
+
+	/// The detection ladder, unchanged from before #194 except that it now
+	/// reports which rung matched. A com.apple.TextEncoding hint gets the
+	/// first try so ambiguous bytes decode the way they were written.
+	private static func decode(_ data: Data, hint: String.Encoding?) -> (String, String.Encoding)? {
+		if let hint, let decoded = String(data: data, encoding: hint) {
+			return (decoded, hint)
+		}
+		if let decoded = String(data: data, encoding: .utf8) {
+			return (decoded, .utf8)
 		}
 
 		// UTF-16 only if a BOM is present (without a BOM, UTF-16 decodes
@@ -78,9 +132,8 @@ class Document: NSDocument {
 		if data.count >= 2 {
 			let bom = (UInt16(data[0]) << 8) | UInt16(data[1])
 			if bom == 0xFEFF || bom == 0xFFFE,
-			   let loadedText = String(data: data, encoding: .utf16) {
-				text = loadedText
-				return
+			   let decoded = String(data: data, encoding: .utf16) {
+				return (decoded, .utf16)
 			}
 		}
 
@@ -90,14 +143,94 @@ class Document: NSDocument {
 		// (0x81/0x8D/0x8F/0x90/0x9D), so files containing them fall
 		// through to Latin-1, then macOS Roman.
 		for encoding: String.Encoding in [.windowsCP1252, .isoLatin1, .macOSRoman] {
-			if let loadedText = String(data: data, encoding: encoding) {
-				text = loadedText
-				return
+			if let decoded = String(data: data, encoding: encoding) {
+				return (decoded, encoding)
 			}
 		}
+		return nil
+	}
 
-		throw NSError(domain: NSOSStatusErrorDomain, code: unimpErr,
-					  userInfo: [NSLocalizedDescriptionKey: "Unable to read file: unsupported text encoding"])
+	// MARK: - Encoding persistence and recovery (#194)
+
+	/// Parses "com.apple.TextEncoding" ("<IANA name>;<CFStringEncoding>",
+	/// e.g. "windows-1252;1280") — the attribute TextEdit and Cocoa's own
+	/// string writers maintain. The number wins; the name is the fallback.
+	private static func encodingFromExtendedAttribute(at url: URL) -> String.Encoding? {
+		var buffer = [UInt8](repeating: 0, count: 256)
+		let length = getxattr(url.path, "com.apple.TextEncoding", &buffer, buffer.count, 0, 0)
+		guard length > 0, let value = String(bytes: buffer[0..<length], encoding: .utf8) else {
+			return nil
+		}
+
+		let parts = value.split(separator: ";", omittingEmptySubsequences: false)
+		if parts.count >= 2, let cfRawValue = UInt32(parts[1]),
+		   CFStringIsEncodingAvailable(CFStringEncoding(cfRawValue)) {
+			return String.Encoding(rawValue: CFStringConvertEncodingToNSStringEncoding(CFStringEncoding(cfRawValue)))
+		}
+		if let name = parts.first, !name.isEmpty {
+			let cfEncoding = CFStringConvertIANACharSetNameToEncoding(String(name) as CFString)
+			if cfEncoding != kCFStringEncodingInvalidId {
+				return String.Encoding(rawValue: CFStringConvertEncodingToNSStringEncoding(cfEncoding))
+			}
+		}
+		return nil
+	}
+
+	/// Writes com.apple.TextEncoding as part of the safe-save itself, so
+	/// the attribute survives the atomic swap (writing it after the fact
+	/// would race the swap — the trap #157 documents). It is a hint, never
+	/// the only record: xattrs vanish on SMB shares, git, and uploads, and
+	/// the read ladder still detects the encoding without it.
+	override func fileAttributesToWrite(to url: URL, ofType typeName: String,
+										for saveOperation: NSDocument.SaveOperationType,
+										originalContentsURL absoluteOriginalContentsURL: URL?) throws -> [String: Any] {
+		var attributes = try super.fileAttributesToWrite(to: url, ofType: typeName,
+														 for: saveOperation,
+														 originalContentsURL: absoluteOriginalContentsURL)
+		if let value = Self.textEncodingAttributeValue(for: readEncoding) {
+			var extended = attributes["NSFileExtendedAttributes"] as? [String: Any] ?? [:]
+			extended["com.apple.TextEncoding"] = Data(value.utf8)
+			attributes["NSFileExtendedAttributes"] = extended
+		}
+		return attributes
+	}
+
+	internal static func textEncodingAttributeValue(for encoding: String.Encoding) -> String? {
+		let cfEncoding = CFStringConvertNSStringEncodingToEncoding(encoding.rawValue)
+		guard cfEncoding != kCFStringEncodingInvalidId,
+			  let ianaName = CFStringConvertEncodingToIANACharSetName(cfEncoding) as String? else {
+			return nil
+		}
+		return "\(ianaName);\(cfEncoding)"
+	}
+
+	/// Short human name for the status bar and error text.
+	var encodingDisplayName: String {
+		switch readEncoding {
+		case .utf8: return hadUTF8BOM ? "UTF-8 BOM" : "UTF-8"
+		case .utf16: return "UTF-16"
+		case .windowsCP1252: return "CP1252"
+		case .isoLatin1: return "Latin-1"
+		case .macOSRoman: return "Mac Roman"
+		default: return String.localizedName(of: readEncoding)
+		}
+	}
+
+	private func encodingUnrepresentableError() -> NSError {
+		NSError(domain: "JotDocumentErrorDomain", code: 1, userInfo: [
+			NSLocalizedDescriptionKey:
+				"This document can no longer be saved in its original \(encodingDisplayName) encoding.",
+			NSLocalizedRecoverySuggestionErrorKey:
+				"It now contains characters that \(encodingDisplayName) can't represent. You can save it as UTF-8 instead, or cancel and remove the new characters.",
+			NSLocalizedRecoveryOptionsErrorKey: ["Save as UTF-8", "Cancel"],
+			NSRecoveryAttempterErrorKey: EncodingRecoveryAttempter(document: self),
+		])
+	}
+
+	/// Called by the recovery attempter after converting to UTF-8, and by
+	/// anything else that changes encoding metadata outside a read.
+	func noteEncodingDidChange() {
+		(windowControllers.first?.contentViewController as? EditorViewController)?.updateFileInfoLabel()
 	}
 
 	// MARK: - Reverting
@@ -163,6 +296,9 @@ class Document: NSDocument {
 			throw NSError(domain: NSOSStatusErrorDomain, code: unimpErr, userInfo: nil)
 		}
 		newDocument.text = self.text
+		newDocument.readEncoding = readEncoding
+		newDocument.hadUTF8BOM = hadUTF8BOM
+		newDocument.lineEnding = lineEnding
 		return newDocument
 	}
 
@@ -359,5 +495,54 @@ class Document: NSDocument {
 				.priority: NSAccessibilityPriorityLevel.high.rawValue
 			]
 		)
+	}
+}
+
+/// Recovery for the unrepresentable-encoding save error (#194): option 0
+/// converts the document to UTF-8 and retries the save. NSDocument presents
+/// save errors as sheets, which drive the delegate-based recovery method —
+/// it forwards to the boolean one and reports back through the selector.
+private final class EncodingRecoveryAttempter: NSObject {
+	private weak var document: Document?
+
+	init(document: Document) {
+		self.document = document
+	}
+
+	override func attemptRecovery(fromError error: Error, optionIndex recoveryOptionIndex: Int) -> Bool {
+		guard recoveryOptionIndex == 0, let document else { return false }
+		// AppKit presents document save errors on the main thread
+		return MainActor.assumeIsolated {
+			document.readEncoding = .utf8
+			document.hadUTF8BOM = false
+			document.noteEncodingDidChange()
+			guard let fileURL = document.fileURL else { return true }
+			// AppKit is still unwinding the failed save when this runs, and
+			// it does not reliably retry after recovery — re-save once the
+			// stack clears. The closure crosses an isolation boundary, so it
+			// carries the URL and looks the document up again rather than
+			// capturing it (same pattern as the recovery announcement). The
+			// isDocumentEdited guard makes a double save harmless.
+			DispatchQueue.main.async {
+				MainActor.assumeIsolated {
+					guard let document = NSDocumentController.shared.document(for: fileURL) as? Document,
+						  document.isDocumentEdited else { return }
+					document.save(nil)
+				}
+			}
+			return true
+		}
+	}
+
+	override func attemptRecovery(fromError error: Error, optionIndex recoveryOptionIndex: Int,
+								  delegate: Any?, didRecoverSelector: Selector?,
+								  contextInfo: UnsafeMutableRawPointer?) {
+		let didRecover = attemptRecovery(fromError: error, optionIndex: recoveryOptionIndex)
+		guard let delegate = delegate as? NSObject, let didRecoverSelector else { return }
+		// The callback signature is (didRecover:contextInfo:) — not
+		// expressible through performSelector, hence the IMP cast
+		typealias Callback = @convention(c) (NSObject, Selector, Bool, UnsafeMutableRawPointer?) -> Void
+		let callback = unsafeBitCast(delegate.method(for: didRecoverSelector), to: Callback.self)
+		callback(delegate, didRecoverSelector, didRecover, contextInfo)
 	}
 }

--- a/Jot/Editor/EditorViewController.swift
+++ b/Jot/Editor/EditorViewController.swift
@@ -37,6 +37,18 @@ class EditorViewController: NSViewController, NSTextViewDelegate {
 	/// Non-nil exactly while the gutter is installed on the scroll view.
 	/// Whether it should be installed is the preference's call alone (#106).
 	private var lineNumberGutter: LineNumberGutterView?
+
+	/// Encoding and line-ending indicator ("CP1252 · CRLF") left of the
+	/// mode popup (#195). Built in code so the storyboard bar's flexible
+	/// center gap absorbs it without re-plumbing existing constraints.
+	private let fileInfoLabel: NSTextField = {
+		let label = NSTextField(labelWithString: "")
+		label.font = .systemFont(ofSize: NSFont.smallSystemFontSize)
+		label.textColor = .secondaryLabelColor
+		label.translatesAutoresizingMaskIntoConstraints = false
+		label.setAccessibilityLabel("File encoding and line endings")
+		return label
+	}()
 	
 	override func viewDidLoad() {
 		super.viewDidLoad()
@@ -47,6 +59,15 @@ class EditorViewController: NSViewController, NSTextViewDelegate {
 		loadFontPreferences()
 		updateWordCount()
 		configureAccessibility()
+
+		if let bar = modePopUpButton.superview {
+			bar.addSubview(fileInfoLabel)
+			NSLayoutConstraint.activate([
+				fileInfoLabel.trailingAnchor.constraint(equalTo: modePopUpButton.leadingAnchor, constant: -8),
+				fileInfoLabel.centerYAnchor.constraint(equalTo: modePopUpButton.centerYAnchor),
+				fileInfoLabel.leadingAnchor.constraint(greaterThanOrEqualTo: wordCountLabel.trailingAnchor, constant: 8),
+			])
+		}
 
 		// Restyle visible range when the user scrolls in markdown mode
 		if let scrollView = textView.enclosingScrollView {
@@ -90,6 +111,19 @@ class EditorViewController: NSViewController, NSTextViewDelegate {
 			object: nil
 		)
 		updateGutterVisibility()
+		// The document association exists by now; loadText can run before it
+		updateFileInfoLabel()
+	}
+
+	/// Refreshes the encoding / line-ending indicator from the document
+	/// (#195). Called on appearance, after loads and reverts, and by the
+	/// document when a failed save was recovered by converting to UTF-8.
+	func updateFileInfoLabel() {
+		guard let document = view.window?.windowController?.document as? Document else {
+			fileInfoLabel.stringValue = ""
+			return
+		}
+		fileInfoLabel.stringValue = "\(document.encodingDisplayName) · \(document.lineEnding.rawValue)"
 	}
 
 	@objc private func fontConfigurationDidChange(_ notification: Notification) {
@@ -725,6 +759,7 @@ class EditorViewController: NSViewController, NSTextViewDelegate {
 			applyStyling()
 		}
 		updateWordCount()
+		updateFileInfoLabel()
 	}
 
 	/// Called by Document after File > Revert to Saved rereads the file.

--- a/Jot/Models/LineEnding.swift
+++ b/Jot/Models/LineEnding.swift
@@ -1,0 +1,55 @@
+//
+//  LineEnding.swift
+//  Jot
+//
+//  The newline convention a file arrived with (#194, #195). The editor
+//  buffer is always normalized to "\n" — NSTextView inserts "\n" on Return
+//  regardless of the file's convention, so keeping the buffer single-
+//  convention avoids mixed endings by construction. The original
+//  convention is restored at save time.
+//
+
+import Foundation
+
+enum LineEnding: String {
+	case lf = "LF"
+	case crlf = "CRLF"
+	case cr = "CR"
+
+	var characters: String {
+		switch self {
+		case .lf: return "\n"
+		case .crlf: return "\r\n"
+		case .cr: return "\r"
+		}
+	}
+
+	/// The convention of the first line break in `string`, or nil when it
+	/// has none. Swift groups "\r\n" into a single Character, so a
+	/// per-Character scan sees each break whole. Unicode's extra breaks
+	/// (U+2028/2029/0085) are deliberately ignored — they stay in the text
+	/// untouched and don't count as a file convention.
+	static func detect(in string: String) -> LineEnding? {
+		for character in string {
+			switch character {
+			case "\r\n": return .crlf
+			case "\r": return .cr
+			case "\n": return .lf
+			default: continue
+			}
+		}
+		return nil
+	}
+
+	/// `string` with every line break replaced by "\n".
+	static func normalizeToLF(_ string: String) -> String {
+		string
+			.replacingOccurrences(of: "\r\n", with: "\n")
+			.replacingOccurrences(of: "\r", with: "\n")
+	}
+
+	/// A normalized (LF-only) string converted back to this convention.
+	func restore(in normalized: String) -> String {
+		self == .lf ? normalized : normalized.replacingOccurrences(of: "\n", with: characters)
+	}
+}

--- a/JotTests/DocumentTests.swift
+++ b/JotTests/DocumentTests.swift
@@ -238,7 +238,14 @@ final class DocumentTests: XCTestCase {
 
         try doc.read(from: data, ofType: "public.plain-text")
 
-        XCTAssertEqual(doc.text, input)
+        // The buffer is normalized to LF (#194) — NSTextView types "\n"
+        // regardless, so a mixed-endings buffer is avoided by construction
+        XCTAssertEqual(doc.text, "line one\nline two\nline three")
+        XCTAssertEqual(doc.lineEnding, .crlf)
+
+        let saved = try doc.data(ofType: "public.plain-text")
+        XCTAssertEqual(String(data: saved, encoding: .utf8), input,
+                       "CRLF must be restored byte-for-byte on save")
     }
 
     // MARK: - Revert to Saved (#119)
@@ -535,6 +542,110 @@ final class DocumentTests: XCTestCase {
             XCTAssertEqual(restored?.displayName, "Recovered Draft — chapter-3.txt",
                            "the title should let the user match the draft to its file")
         }
+    }
+
+    // MARK: - Encoding preservation (#194)
+
+    func testCP1252RoundTripPreservesBytes() throws {
+        let doc = Document()
+        // 0x93/0x94 smart quotes, 0x97 em-dash — CP1252-only byte values
+        let input = Data([0x93, 0x48, 0x69, 0x94, 0x97, 0x20, 0x65, 0x6E, 0x64])
+
+        try doc.read(from: input, ofType: "public.plain-text")
+        XCTAssertEqual(doc.readEncoding, .windowsCP1252)
+
+        let saved = try doc.data(ofType: "public.plain-text")
+        XCTAssertEqual(saved, input, "an untouched CP1252 file must round-trip byte-for-byte")
+    }
+
+    func testUTF8BOMIsStrippedFromBufferAndRestoredOnSave() throws {
+        let doc = Document()
+        let bom = Data([0xEF, 0xBB, 0xBF])
+        let input = bom + Data("hello".utf8)
+
+        try doc.read(from: input, ofType: "public.plain-text")
+
+        XCTAssertEqual(doc.text, "hello",
+                       "U+FEFF must not leak into the editor buffer")
+        XCTAssertTrue(doc.hadUTF8BOM)
+
+        let saved = try doc.data(ofType: "public.plain-text")
+        XCTAssertEqual(saved, input, "the BOM bytes must be restored on save")
+    }
+
+    func testFileWithoutBOMNeverGainsOne() throws {
+        let doc = Document()
+        try doc.read(from: Data("plain".utf8), ofType: "public.plain-text")
+
+        let saved = try doc.data(ofType: "public.plain-text")
+        XCTAssertEqual(saved, Data("plain".utf8))
+    }
+
+    func testUnrepresentableContentFailsWithRecoverableError() throws {
+        let doc = Document()
+        let cp1252Bytes = Data([0x93, 0x48, 0x69, 0x94])
+        try doc.read(from: cp1252Bytes, ofType: "public.plain-text")
+        doc.text += " 😀"
+
+        XCTAssertThrowsError(try doc.data(ofType: "public.plain-text")) { error in
+            let nsError = error as NSError
+            let options = nsError.userInfo[NSLocalizedRecoveryOptionsErrorKey] as? [String]
+            XCTAssertEqual(options?.first, "Save as UTF-8",
+                           "the error must offer conversion as an explicit choice, never convert silently")
+            XCTAssertNotNil(nsError.userInfo[NSRecoveryAttempterErrorKey])
+        }
+    }
+
+    func testEncodingRecoveryConvertsToUTF8() throws {
+        let doc = Document()
+        try doc.read(from: Data([0x93, 0x48, 0x69, 0x94]), ofType: "public.plain-text")
+        doc.text += " 😀"
+
+        var thrown: NSError?
+        XCTAssertThrowsError(try doc.data(ofType: "public.plain-text")) { thrown = $0 as NSError }
+        let attempter = try XCTUnwrap(thrown?.userInfo[NSRecoveryAttempterErrorKey] as? NSObject)
+
+        let recovered = attempter.attemptRecovery(fromError: thrown!, optionIndex: 0)
+
+        XCTAssertTrue(recovered)
+        XCTAssertEqual(doc.readEncoding, .utf8)
+        XCTAssertNoThrow(try doc.data(ofType: "public.plain-text"),
+                         "after converting to UTF-8 the save must succeed")
+    }
+
+    func testFileAttributesIncludeTextEncodingXattr() throws {
+        let doc = Document()
+        try doc.read(from: Data([0x93, 0x48, 0x94]), ofType: "public.plain-text")
+
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("xattr-\(UUID().uuidString).txt")
+        let attributes = try doc.fileAttributesToWrite(
+            to: url, ofType: "public.plain-text", for: .saveOperation, originalContentsURL: nil)
+
+        let extended = attributes["NSFileExtendedAttributes"] as? [String: Any]
+        let value = extended?["com.apple.TextEncoding"] as? Data
+        XCTAssertEqual(value.flatMap { String(data: $0, encoding: .utf8) }, "windows-1252;1280",
+                       "the xattr must carry the TextEdit-compatible IANA-name;CFStringEncoding pair")
+    }
+
+    func testXattrHintWinsOverDetectionLadder() throws {
+        // Plain ASCII decodes as UTF-8 on the ladder's first rung; the
+        // com.apple.TextEncoding hint must take precedence so the file
+        // saves back in the encoding it was written with
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("hint-\(UUID().uuidString).txt")
+        try Data("plain ascii".utf8).write(to: url)
+        defer { try? FileManager.default.removeItem(at: url) }
+        let xattrValue = "iso-8859-1;513"
+        _ = xattrValue.withCString { valuePtr in
+            setxattr(url.path, "com.apple.TextEncoding", valuePtr, strlen(valuePtr), 0, 0)
+        }
+
+        let doc = Document()
+        try doc.read(from: url, ofType: "public.plain-text")
+
+        XCTAssertEqual(doc.readEncoding, .isoLatin1)
+        XCTAssertEqual(doc.text, "plain ascii")
     }
 
 }

--- a/JotTests/LineEndingTests.swift
+++ b/JotTests/LineEndingTests.swift
@@ -1,0 +1,48 @@
+//
+//  LineEndingTests.swift
+//  JotTests
+//
+//  Detection, normalization, and restoration of file line-ending
+//  conventions (#194, #195).
+//
+
+import XCTest
+@testable import Jot
+
+final class LineEndingTests: XCTestCase {
+
+    func testDetectsFirstConvention() {
+        XCTAssertEqual(LineEnding.detect(in: "a\nb"), .lf)
+        XCTAssertEqual(LineEnding.detect(in: "a\r\nb"), .crlf)
+        XCTAssertEqual(LineEnding.detect(in: "a\rb"), .cr)
+        XCTAssertNil(LineEnding.detect(in: "no breaks"))
+        XCTAssertNil(LineEnding.detect(in: ""))
+    }
+
+    func testMixedEndingsFirstOccurrenceWins() {
+        XCTAssertEqual(LineEnding.detect(in: "a\r\nb\nc\rd"), .crlf)
+        XCTAssertEqual(LineEnding.detect(in: "a\nb\r\nc"), .lf)
+    }
+
+    func testUnicodeSeparatorsAreIgnored() {
+        // U+2028 line separator is not a file convention (#194)
+        XCTAssertEqual(LineEnding.detect(in: "a\u{2028}b\nc"), .lf)
+        XCTAssertNil(LineEnding.detect(in: "a\u{2028}b"))
+    }
+
+    func testNormalizeToLF() {
+        XCTAssertEqual(LineEnding.normalizeToLF("a\r\nb\rc\nd"), "a\nb\nc\nd")
+    }
+
+    func testRestoreConvention() {
+        XCTAssertEqual(LineEnding.crlf.restore(in: "a\nb\nc"), "a\r\nb\r\nc")
+        XCTAssertEqual(LineEnding.cr.restore(in: "a\nb"), "a\rb")
+        XCTAssertEqual(LineEnding.lf.restore(in: "a\nb"), "a\nb")
+    }
+
+    func testNormalizeThenRestoreRoundTrips() {
+        let original = "one\r\ntwo\r\nthree\r\n"
+        let normalized = LineEnding.normalizeToLF(original)
+        XCTAssertEqual(LineEnding.crlf.restore(in: normalized), original)
+    }
+}


### PR DESCRIPTION
## Summary

Phase 2 of `docs/file-handling-plan.md`: files round-trip in their original encoding and line-ending convention instead of being silently rewritten as UTF-8/LF. Design follows the TextEdit pattern verified during planning research.

### Encoding (#194)
- The existing detection ladder (UTF-8 → UTF-16 BOM → CP1252 → Latin-1 → Mac Roman) is unchanged, but now records which rung matched; saves encode with that.
- The `com.apple.TextEncoding` xattr (`<IANA name>;<CFStringEncoding>`, e.g. `windows-1252;1280`) is consulted first on read and written on save via `fileAttributesToWrite` — the safe-save channel, so it survives the atomic swap. It's a hint, never the only record.
- UTF-8 BOM: stripped from the buffer on read (`String(data:encoding:)` otherwise leaks U+FEFF into counts and searches), restored on save; files without one never gain one.
- **Unrepresentable edits** (a CP1252 file gaining an emoji): the save fails with a recoverable error — "Save as UTF-8" converts explicitly and re-saves; Cancel leaves the file untouched. Never a silent conversion. Autosave attempts fail quietly until the user sees the alert at an explicit save/close.

### Line endings (#194/#195)
- Detected by first occurrence on read; buffer normalized to LF internally (NSTextView inserts LF on Return regardless, so mixed-endings files are avoided by construction — the pre-4.2 CotEditor pattern); original convention restored on save.

### Status bar (#195)
- New passive indicator left of the mode popup: "UTF-8 · LF", "CP1252 · CRLF", "UTF-8 BOM · LF", etc. No picker — visibility only, per the issue. Built programmatically in the bar's flexible gap.

## Tests

291 total (13 new), all green locally:
- CP1252 byte-for-byte round trip; CRLF round trip (existing test updated to the normalize-internally contract); BOM strip/restore; no-BOM never gains one
- Unrepresentable content throws with "Save as UTF-8" recovery option; recovery converts and subsequent saves succeed
- xattr written with the TextEdit-compatible value; xattr hint beats the detection ladder (ASCII file marked Latin-1 reads as Latin-1)
- LineEnding detection/normalization/restoration unit tests, including mixed endings and U+2028 exclusion

## Manual test suggestions

- Open a CP1252 or Latin-1 file (BBEdit can save one), confirm the status indicator, edit, save, reopen elsewhere — encoding preserved.
- Type an emoji into that file, ⌘S → expect the Save as UTF-8 / Cancel alert; both paths.
- A CRLF file (from Windows or `printf 'a\r\nb\r\n' > test.txt`), edit, save, `hexdump -C` — CRLF preserved, no mixed endings.
- New untitled document shows "UTF-8 · LF".

Closes #194. Closes #195.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015SvAwERh6dke6vSFmjNXVg
