### PR TITLE
feat: expand document types to JSON, XML, and a text catch-all (#193)

### DIFF
--- a/Jot/Editor/EditorTextView.swift
+++ b/Jot/Editor/EditorTextView.swift
@@ -13,12 +13,16 @@ import UniformTypeIdentifiers
 
 class EditorTextView: NSTextView {
 
-    // UTIs the app can open, matching Info.plist declarations.
-    private static let supportedTypes: [UTType] = [
-        .plainText,
-        UTType("net.daringfireball.markdown")!,
-        .sourceCode,
-    ]
+    // UTIs the app can open, derived from the Info.plist document-type
+    // declarations so this list can't drift from them (#193). The fallback
+    // only matters if the plist declarations ever go missing entirely.
+    static let supportedTypes: [UTType] = {
+        let declarations = Bundle.main.object(forInfoDictionaryKey: "CFBundleDocumentTypes")
+            as? [[String: Any]] ?? []
+        let identifiers = declarations.flatMap { $0["LSItemContentTypes"] as? [String] ?? [] }
+        let types = identifiers.compactMap { UTType($0) }
+        return types.isEmpty ? [.plainText] : types
+    }()
 
     override func draggingEntered(_ sender: NSDraggingInfo) -> NSDragOperation {
         if let urls = extractFileURLs(from: sender.draggingPasteboard) {

--- a/Jot/Resources/Info.plist
+++ b/Jot/Resources/Info.plist
@@ -36,12 +36,54 @@
 			<key>CFBundleTypeName</key>
 			<string>Source Code</string>
 			<key>CFBundleTypeRole</key>
-			<string>Viewer</string>
+			<string>Editor</string>
 			<key>LSHandlerRank</key>
 			<string>Alternate</string>
 			<key>LSItemContentTypes</key>
 			<array>
 				<string>public.source-code</string>
+			</array>
+			<key>NSDocumentClass</key>
+			<string>$(PRODUCT_MODULE_NAME).Document</string>
+		</dict>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>JSON Document</string>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>LSHandlerRank</key>
+			<string>Alternate</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>public.json</string>
+			</array>
+			<key>NSDocumentClass</key>
+			<string>$(PRODUCT_MODULE_NAME).Document</string>
+		</dict>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>XML Document</string>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>LSHandlerRank</key>
+			<string>Alternate</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>public.xml</string>
+			</array>
+			<key>NSDocumentClass</key>
+			<string>$(PRODUCT_MODULE_NAME).Document</string>
+		</dict>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>Text Document</string>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>LSHandlerRank</key>
+			<string>None</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>public.text</string>
 			</array>
 			<key>NSDocumentClass</key>
 			<string>$(PRODUCT_MODULE_NAME).Document</string>

--- a/JotTests/EditorTextViewTests.swift
+++ b/JotTests/EditorTextViewTests.swift
@@ -8,6 +8,7 @@
 //
 
 import XCTest
+import UniformTypeIdentifiers
 @testable import Jot
 
 @MainActor
@@ -88,5 +89,20 @@ final class EditorTextViewTests: XCTestCase {
 		XCTAssertNil(EditorTextView.markdownLink(
 			wrapping: "line one\nline two",
 			around: "https://example.com"))
+	}
+
+	// MARK: - Supported types (#193)
+
+	/// Hosted tests run inside Jot.app, so this checks the derivation AND
+	/// the Info.plist declarations together — the drag-drop accept list
+	/// can no longer drift from what the app declares it can open.
+	func testSupportedTypesDeriveFromInfoPlistDeclarations() throws {
+		let types = EditorTextView.supportedTypes
+		for identifier in ["public.plain-text", "net.daringfireball.markdown",
+						   "public.source-code", "public.json", "public.xml", "public.text"] {
+			let type = try XCTUnwrap(UTType(identifier))
+			XCTAssertTrue(types.contains(type),
+						  "\(identifier) is declared in Info.plist and must be accepted for drops")
+		}
 	}
 }


### PR DESCRIPTION
## Summary

Phase 3 of `docs/file-handling-plan.md` (reduced to #193 alone — #98 was verified already fixed and closed):

- **`public.json` and `public.xml`** added as Editor / Alternate document types — their UTIs don't conform to `public.plain-text` or `public.source-code`, so Jot previously refused them outright.
- **`public.text` catch-all** as Viewer / rank None — YAML, TOML, logs, and config files now open via "Open With" without Jot claiming default-handler status for anything.
- **`public.source-code` role corrected** Viewer → Editor: the app edits and saves these files, so the declaration now matches the behavior.
- **`EditorTextView.supportedTypes` derives from the Info.plist declarations** at runtime instead of hand-mirroring them — the drag-drop accept list and the document-type list can no longer drift apart (same source-of-truth lesson as #211). A new hosted test locks the derivation and the plist declarations together.

## Tests

292 total (1 new), all green locally.

## Manual test suggestions

- Right-click a `.json`, `.xml`, and `.yaml` file → Open With → Jot appears and opens them.
- Drag those files onto an open editor window — accepted (previously refused for json/xml).
- Jot should not have become the *default* app for anything it wasn't before.
- Note: Finder's Open With menu is fed by the LaunchServices cache, which can lag — launch the new build once first, and give it a moment before concluding a type is missing.

Closes #193.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015SvAwERh6dke6vSFmjNXVg
