### PR TITLE
feat: open markdown files in markdown mode by inference (#158)

### DIFF
--- a/Jot/App/Document.swift
+++ b/Jot/App/Document.swift
@@ -57,7 +57,9 @@ class Document: NSDocument {
 			// A .md file opens in markdown mode without touching the popup
 			// (#158). Window restoration runs restoreState afterward, so a
 			// mode the user chose explicitly still wins over this default.
-			contentViewController.applyInitialMode(EditorMode.inferred(fromTypeIdentifier: fileType))
+			contentViewController.applyInitialMode(EditorMode.inferred(
+				fromTypeIdentifier: fileType,
+				filenameExtension: fileURL?.pathExtension))
 			contentViewController.loadText(text)
 		}
 	}

--- a/Jot/App/Document.swift
+++ b/Jot/App/Document.swift
@@ -54,6 +54,10 @@ class Document: NSDocument {
 		self.addWindowController(windowController)
 
 		if let contentViewController = windowController.contentViewController as? EditorViewController {
+			// A .md file opens in markdown mode without touching the popup
+			// (#158). Window restoration runs restoreState afterward, so a
+			// mode the user chose explicitly still wins over this default.
+			contentViewController.applyInitialMode(EditorMode.inferred(fromTypeIdentifier: fileType))
 			contentViewController.loadText(text)
 		}
 	}

--- a/Jot/Editor/EditorViewController.swift
+++ b/Jot/Editor/EditorViewController.swift
@@ -748,6 +748,16 @@ class EditorViewController: NSViewController, NSTextViewDelegate {
 	// chain to NSDocument, whose machinery flushes the live text view in
 	// Document.data(ofType:) -- one save path, one flush point (#118, #125).
 
+	/// Sets the mode inferred from the document type before the initial
+	/// text load (#158). Selects the popup directly instead of going
+	/// through updateModeUI: nothing "switched", the document opened this
+	/// way, so the mode-change announcement would be noise. Call before
+	/// loadText so the initial styling pass runs once, in the right mode.
+	func applyInitialMode(_ mode: EditorMode) {
+		currentMode = mode
+		modePopUpButton.selectItem(withTitle: mode == .markdown ? "Markdown" : "Plain Text")
+	}
+
 	/// The single place that assigns textView.string. Setting the string
 	/// does not fire textDidChange, so the styled-range reset (#139) and
 	/// word-count refresh must happen here — funneled so a new call site

--- a/Jot/Models/EditorMode.swift
+++ b/Jot/Models/EditorMode.swift
@@ -12,19 +12,32 @@ enum EditorMode {
 	case plainText
 	case markdown
 
-	/// Initial mode for a document of the given type (#158): markdown
-	/// types open in markdown mode, everything else — including untitled
-	/// documents — opens in plain text. This is only the default at open
-	/// time; explicit per-document state (restoration, the planned #157
-	/// xattr) is applied afterward and wins.
-	static func inferred(fromTypeIdentifier identifier: String?) -> EditorMode {
-		// The identifier matches the UTImportedTypeDeclarations entry in
-		// Info.plist, which maps .md/.markdown/.mdown to it
-		guard let identifier,
-			  let type = UTType(identifier),
-			  let markdown = UTType("net.daringfireball.markdown") else {
-			return .plainText
+	/// Extensions that open in markdown mode. Matches the
+	/// UTImportedTypeDeclarations entry in Info.plist.
+	private static let markdownExtensions: Set<String> = ["md", "markdown", "mdown"]
+
+	/// Initial mode for a document (#158): markdown files open in markdown
+	/// mode, everything else — including untitled documents — opens in
+	/// plain text. This is only the default at open time; explicit
+	/// per-document state (restoration, the planned #157 xattr) is applied
+	/// afterward and wins.
+	///
+	/// The filename extension is the primary signal, not the UTI: there is
+	/// no standard markdown UTI, and any installed app that *exports* its
+	/// own (iA Writer's net.ia.markdown, say) owns what .md resolves to —
+	/// Jot's imported net.daringfireball.markdown declaration is only a
+	/// fallback vote in that database. Conformance is still checked second
+	/// so a markdown-typed document without a URL infers correctly.
+	static func inferred(fromTypeIdentifier identifier: String?, filenameExtension: String?) -> EditorMode {
+		if let filenameExtension, markdownExtensions.contains(filenameExtension.lowercased()) {
+			return .markdown
 		}
-		return type.conforms(to: markdown) ? .markdown : .plainText
+		if let identifier,
+		   let type = UTType(identifier),
+		   let markdown = UTType("net.daringfireball.markdown"),
+		   type.conforms(to: markdown) {
+			return .markdown
+		}
+		return .plainText
 	}
 }

--- a/Jot/Models/EditorMode.swift
+++ b/Jot/Models/EditorMode.swift
@@ -6,8 +6,25 @@
 //
 
 import Foundation
+import UniformTypeIdentifiers
 
 enum EditorMode {
 	case plainText
 	case markdown
+
+	/// Initial mode for a document of the given type (#158): markdown
+	/// types open in markdown mode, everything else — including untitled
+	/// documents — opens in plain text. This is only the default at open
+	/// time; explicit per-document state (restoration, the planned #157
+	/// xattr) is applied afterward and wins.
+	static func inferred(fromTypeIdentifier identifier: String?) -> EditorMode {
+		// The identifier matches the UTImportedTypeDeclarations entry in
+		// Info.plist, which maps .md/.markdown/.mdown to it
+		guard let identifier,
+			  let type = UTType(identifier),
+			  let markdown = UTType("net.daringfireball.markdown") else {
+			return .plainText
+		}
+		return type.conforms(to: markdown) ? .markdown : .plainText
+	}
 }

--- a/JotTests/EditorModeTests.swift
+++ b/JotTests/EditorModeTests.swift
@@ -3,6 +3,9 @@
 //  JotTests
 //
 //  Tests for the initial-mode inference from the document type (#158).
+//  The filename extension is the primary signal: .md's UTI resolves to
+//  whatever markdown app on the machine exports its own type (iA Writer's
+//  net.ia.markdown, for one), so the UTI alone is machine-dependent.
 //
 
 import XCTest
@@ -10,28 +13,71 @@ import XCTest
 
 final class EditorModeTests: XCTestCase {
 
-	func testMarkdownTypeInfersMarkdownMode() {
-		XCTAssertEqual(EditorMode.inferred(fromTypeIdentifier: "net.daringfireball.markdown"), .markdown)
+	// MARK: - Extension signal
+
+	func testMarkdownExtensionsInferMarkdownMode() {
+		for ext in ["md", "markdown", "mdown"] {
+			XCTAssertEqual(
+				EditorMode.inferred(fromTypeIdentifier: "public.plain-text", filenameExtension: ext),
+				.markdown, "\(ext) files must open in markdown mode")
+		}
+	}
+
+	func testExtensionMatchIsCaseInsensitive() {
+		XCTAssertEqual(
+			EditorMode.inferred(fromTypeIdentifier: nil, filenameExtension: "MD"),
+			.markdown)
+	}
+
+	func testForeignMarkdownUTIWithMarkdownExtensionInfersMarkdownMode() {
+		// The real-world case this exists for: another app exports its own
+		// markdown UTI, so the identifier is unrecognizable but the
+		// extension still says markdown
+		XCTAssertEqual(
+			EditorMode.inferred(fromTypeIdentifier: "com.example.other-apps-markdown", filenameExtension: "md"),
+			.markdown)
+	}
+
+	func testTextExtensionInfersPlainTextMode() {
+		XCTAssertEqual(
+			EditorMode.inferred(fromTypeIdentifier: "public.plain-text", filenameExtension: "txt"),
+			.plainText)
+	}
+
+	// MARK: - UTI signal (no URL)
+
+	func testMarkdownTypeWithoutExtensionInfersMarkdownMode() {
+		XCTAssertEqual(
+			EditorMode.inferred(fromTypeIdentifier: "net.daringfireball.markdown", filenameExtension: nil),
+			.markdown)
 	}
 
 	func testPlainTextTypeInfersPlainTextMode() {
 		// Markdown conforms to plain text, but not the other way around —
 		// a plain .txt file must not open styled
-		XCTAssertEqual(EditorMode.inferred(fromTypeIdentifier: "public.plain-text"), .plainText)
+		XCTAssertEqual(
+			EditorMode.inferred(fromTypeIdentifier: "public.plain-text", filenameExtension: nil),
+			.plainText)
 	}
 
 	func testOtherDeclaredTypesInferPlainTextMode() {
-		XCTAssertEqual(EditorMode.inferred(fromTypeIdentifier: "public.json"), .plainText)
-		XCTAssertEqual(EditorMode.inferred(fromTypeIdentifier: "public.xml"), .plainText)
-		XCTAssertEqual(EditorMode.inferred(fromTypeIdentifier: "public.source-code"), .plainText)
+		for identifier in ["public.json", "public.xml", "public.source-code"] {
+			XCTAssertEqual(
+				EditorMode.inferred(fromTypeIdentifier: identifier, filenameExtension: nil),
+				.plainText, "\(identifier) must open in plain text mode")
+		}
 	}
 
-	func testNilTypeInfersPlainTextMode() {
-		// Untitled documents and anything else without a resolvable type
-		XCTAssertEqual(EditorMode.inferred(fromTypeIdentifier: nil), .plainText)
+	func testNilTypeAndExtensionInfersPlainTextMode() {
+		// Untitled documents
+		XCTAssertEqual(
+			EditorMode.inferred(fromTypeIdentifier: nil, filenameExtension: nil),
+			.plainText)
 	}
 
 	func testUnknownTypeInfersPlainTextMode() {
-		XCTAssertEqual(EditorMode.inferred(fromTypeIdentifier: "com.example.not-a-real-type"), .plainText)
+		XCTAssertEqual(
+			EditorMode.inferred(fromTypeIdentifier: "com.example.not-a-real-type", filenameExtension: nil),
+			.plainText)
 	}
 }

--- a/JotTests/EditorModeTests.swift
+++ b/JotTests/EditorModeTests.swift
@@ -1,0 +1,37 @@
+//
+//  EditorModeTests.swift
+//  JotTests
+//
+//  Tests for the initial-mode inference from the document type (#158).
+//
+
+import XCTest
+@testable import Jot
+
+final class EditorModeTests: XCTestCase {
+
+	func testMarkdownTypeInfersMarkdownMode() {
+		XCTAssertEqual(EditorMode.inferred(fromTypeIdentifier: "net.daringfireball.markdown"), .markdown)
+	}
+
+	func testPlainTextTypeInfersPlainTextMode() {
+		// Markdown conforms to plain text, but not the other way around —
+		// a plain .txt file must not open styled
+		XCTAssertEqual(EditorMode.inferred(fromTypeIdentifier: "public.plain-text"), .plainText)
+	}
+
+	func testOtherDeclaredTypesInferPlainTextMode() {
+		XCTAssertEqual(EditorMode.inferred(fromTypeIdentifier: "public.json"), .plainText)
+		XCTAssertEqual(EditorMode.inferred(fromTypeIdentifier: "public.xml"), .plainText)
+		XCTAssertEqual(EditorMode.inferred(fromTypeIdentifier: "public.source-code"), .plainText)
+	}
+
+	func testNilTypeInfersPlainTextMode() {
+		// Untitled documents and anything else without a resolvable type
+		XCTAssertEqual(EditorMode.inferred(fromTypeIdentifier: nil), .plainText)
+	}
+
+	func testUnknownTypeInfersPlainTextMode() {
+		XCTAssertEqual(EditorMode.inferred(fromTypeIdentifier: "com.example.not-a-real-type"), .plainText)
+	}
+}


### PR DESCRIPTION
## Summary

Phase 4 of `docs/file-handling-plan.md`:

- **`EditorMode.inferred(fromTypeIdentifier:)`** — pure static mapping from a document's UTI to its initial mode: conformance to `net.daringfireball.markdown` → markdown; everything else, including untitled documents, → plain text.
- **Hooked in `makeWindowControllers` before `loadText`**, so the initial styling pass runs once, already in the right mode.
- **Precedence comes free**: window restoration runs `restoreState` after window creation and sets the mode explicitly, so a mode the user chose still wins over the inference. #157's xattr will slot into the same ordering.
- **`applyInitialMode` selects the popup directly** rather than via `updateModeUI` — nothing "switched" at open time, so the mode-change accessibility announcement stays quiet.

## Tests

297 total (5 new), all green locally. New `EditorModeTests` covers the markdown UTI, plain text (which markdown conforms *to*, but must not infer *from*), the other declared types (json/xml/source-code), nil (untitled), and an unknown identifier.

## Manual test suggestions

- Open a `.md` file → popup reads Markdown, styling applied, no VoiceOver "Switched to…" announcement on open.
- Open a `.txt`, `.json`, or untitled document → plain text as before.
- Open a `.md`, switch it to Plain Text, quit with it open, relaunch → restores in Plain Text (restoration beats inference).

Closes #158.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015SvAwERh6dke6vSFmjNXVg
