### PR TITLE
feat: add Duplicate, Rename…, and Move To… to the File menu (#126)

### DIFF
--- a/Jot/Resources/Base.lproj/Main.storyboard
+++ b/Jot/Resources/Base.lproj/Main.storyboard
@@ -99,6 +99,24 @@
                                                 <action selector="saveDocument:" target="Ady-hI-5gd" id="teZ-XB-qJY"/>
                                             </connections>
                                         </menuItem>
+                                        <menuItem title="Duplicate" keyEquivalent="S" id="Dup-mi-126">
+                                            <modifierMask key="keyEquivalentModifierMask" shift="YES" command="YES"/>
+                                            <connections>
+                                                <action selector="duplicateDocument:" target="Ady-hI-5gd" id="Dup-ac-126"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Rename…" id="Ren-mi-126">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="renameDocument:" target="Ady-hI-5gd" id="Ren-ac-126"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Move To…" id="Mov-mi-126">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="moveDocument:" target="Ady-hI-5gd" id="Mov-ac-126"/>
+                                            </connections>
+                                        </menuItem>
                                         <menuItem title="Revert to Saved" keyEquivalent="r" id="KaW-ft-85H">
                                             <connections>
                                                 <action selector="revertDocumentToSaved:" target="Ady-hI-5gd" id="iJ3-Pv-kwq"/>

--- a/Jot/Resources/Base.lproj/Main.storyboard
+++ b/Jot/Resources/Base.lproj/Main.storyboard
@@ -105,6 +105,12 @@
                                                 <action selector="duplicateDocument:" target="Ady-hI-5gd" id="Dup-ac-126"/>
                                             </connections>
                                         </menuItem>
+                                        <menuItem title="Save As…" alternate="YES" keyEquivalent="S" id="Sas-mi-126">
+                                            <modifierMask key="keyEquivalentModifierMask" option="YES" shift="YES" command="YES"/>
+                                            <connections>
+                                                <action selector="saveDocumentAs:" target="Ady-hI-5gd" id="Sas-ac-126"/>
+                                            </connections>
+                                        </menuItem>
                                         <menuItem title="Rename…" id="Ren-mi-126">
                                             <modifierMask key="keyEquivalentModifierMask"/>
                                             <connections>


### PR DESCRIPTION
## Summary

Phase 5 of `docs/file-handling-plan.md` — storyboard-only:

- **Duplicate (⇧⌘S), Rename…, Move To…** added to the File menu between Save… and Revert to Saved, matching TextEdit's order for an autosaving document app.
- All three target **First Responder** with NSDocument's stock selectors (`duplicateDocument:`, `renameDocument:`, `moveDocument:`) — implementation, enabling, and validation come from AppKit, and the existing `Document.duplicate()` override (which carries encoding/line-ending state per #194) is finally reachable from the UI.
- ⇧⌘S on Duplicate also enables the standard **Option-key "Save As…" substitution** in the open File menu.

No code changes.

## Tests

301 tests, all green locally (no new tests — there is no logic here; AppKit owns the behavior).

## Manual test suggestions

- Open a saved document: all three items enabled. Duplicate forks a new untitled copy carrying the text (and encoding/line endings — the #194 fields ride along via `duplicate()`).
- Rename… puts the title bar into inline edit; Move To… shows the location popover.
- Hold Option with the File menu open → Duplicate becomes Save As….
- Untitled document: Rename…/Move To… should be disabled until first save (AppKit's validation).

Closes #126.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015SvAwERh6dke6vSFmjNXVg
