### PR TITLE
feat: persist an explicit mode choice per document via xattr (#157)

### DIFF
--- a/Jot/App/Document.swift
+++ b/Jot/App/Document.swift
@@ -27,6 +27,14 @@ class Document: NSDocument {
 	/// The buffer is normalized to LF; this convention is restored on save.
 	nonisolated(unsafe) var lineEnding: LineEnding = .lf
 
+	/// Mode the user explicitly chose for this document (#157), nil while
+	/// the mode is only the inferred or default one. Once set it is always
+	/// recorded — "overrides, not snapshots" protects settings the user
+	/// never touched, not ones they did. Persisted in the view-settings
+	/// extended attribute; untitled documents carry it in memory until
+	/// their first save writes it.
+	nonisolated(unsafe) var modeOverride: EditorMode?
+
 	/// Encoding parsed from the file's com.apple.TextEncoding extended
 	/// attribute, alive only while a URL-based read is in flight — the
 	/// data-based read consults it for its first decoding attempt.
@@ -54,12 +62,9 @@ class Document: NSDocument {
 		self.addWindowController(windowController)
 
 		if let contentViewController = windowController.contentViewController as? EditorViewController {
-			// A .md file opens in markdown mode without touching the popup
-			// (#158). Window restoration runs restoreState afterward, so a
-			// mode the user chose explicitly still wins over this default.
-			contentViewController.applyInitialMode(EditorMode.inferred(
-				fromTypeIdentifier: fileType,
-				filenameExtension: fileURL?.pathExtension))
+			// Window restoration runs restoreState afterward, so a mode from
+			// the saved session still wins over this initial value.
+			contentViewController.applyInitialMode(initialEditorMode)
 			contentViewController.loadText(text)
 		}
 	}
@@ -100,6 +105,7 @@ class Document: NSDocument {
 		// implementation funnels down to read(from:ofType:) with bare data
 		xattrEncodingHint = Self.encodingFromExtendedAttribute(at: url)
 		defer { xattrEncodingHint = nil }
+		modeOverride = Self.modeOverrideFromExtendedAttribute(at: url)
 		try super.read(from: url, ofType: typeName)
 	}
 
@@ -200,7 +206,66 @@ class Document: NSDocument {
 			extended["com.apple.TextEncoding"] = Data(value.utf8)
 			attributes["NSFileExtendedAttributes"] = extended
 		}
+		if let modeOverride, let value = Self.viewSettingsAttributeValue(mode: modeOverride) {
+			var extended = attributes["NSFileExtendedAttributes"] as? [String: Any] ?? [:]
+			extended[Self.viewSettingsAttributeName] = value
+			attributes["NSFileExtendedAttributes"] = extended
+		}
 		return attributes
+	}
+
+	// MARK: - Per-document view settings (#157)
+
+	// The same xattr strategy as com.apple.TextEncoding above: settings
+	// travel with the file through Finder copies and Time Machine, the
+	// content stays byte-for-byte plain text, and a lost attribute (git,
+	// email, uploads) degrades to inference — a preference, never data.
+
+	internal static let viewSettingsAttributeName = "com.brian.jot.view-settings"
+
+	/// Mode the editor should open with: the user's recorded choice, else
+	/// inference from the file type (#157, #158). Restoration state is
+	/// applied later and beats both.
+	var initialEditorMode: EditorMode {
+		modeOverride ?? EditorMode.inferred(fromTypeIdentifier: fileType,
+											filenameExtension: fileURL?.pathExtension)
+	}
+
+	/// Called by the editor when the user explicitly changes the mode.
+	/// Writes the attribute to disk immediately instead of touching the
+	/// change count: NSDocument.h is explicit that even "discardable"
+	/// changes mark the document edited, and a view toggle must not show
+	/// an Edited state or create Versions entries. The immediate write
+	/// can't be lost to a later safe-save swap because every save also
+	/// re-applies the attribute via fileAttributesToWrite; untitled
+	/// documents carry the override in memory until their first save.
+	func noteUserChangedMode(_ mode: EditorMode) {
+		modeOverride = mode
+		guard let path = fileURL?.path,
+			  let value = Self.viewSettingsAttributeValue(mode: mode) else { return }
+		_ = value.withUnsafeBytes { buffer in
+			setxattr(path, Self.viewSettingsAttributeName, buffer.baseAddress, buffer.count, 0, 0)
+		}
+	}
+
+	/// The attribute is a keyed plist rather than a bare value so the
+	/// planned line-numbers and word-count overrides (#224) extend it
+	/// without a format break.
+	private static func modeOverrideFromExtendedAttribute(at url: URL) -> EditorMode? {
+		var buffer = [UInt8](repeating: 0, count: 4096)
+		let length = getxattr(url.path, viewSettingsAttributeName, &buffer, buffer.count, 0, 0)
+		guard length > 0 else { return nil }
+		guard let plist = try? PropertyListSerialization.propertyList(
+				from: Data(buffer[0..<length]), format: nil) as? [String: Any],
+			  let rawMode = plist["mode"] as? String else {
+			return nil
+		}
+		return EditorMode(rawValue: rawMode)
+	}
+
+	internal static func viewSettingsAttributeValue(mode: EditorMode) -> Data? {
+		try? PropertyListSerialization.data(
+			fromPropertyList: ["mode": mode.rawValue], format: .binary, options: 0)
 	}
 
 	internal static func textEncodingAttributeValue(for encoding: String.Encoding) -> String? {
@@ -307,6 +372,7 @@ class Document: NSDocument {
 		newDocument.readEncoding = readEncoding
 		newDocument.hadUTF8BOM = hadUTF8BOM
 		newDocument.lineEnding = lineEnding
+		newDocument.modeOverride = modeOverride
 		return newDocument
 	}
 

--- a/Jot/Editor/EditorViewController.swift
+++ b/Jot/Editor/EditorViewController.swift
@@ -422,6 +422,14 @@ class EditorViewController: NSViewController, NSTextViewDelegate {
 
 		updateModeUI()
 		invalidateRestorableState()
+		noteUserChangedMode()
+	}
+
+	/// Records an explicit mode change on the document so it persists in
+	/// the view-settings xattr (#157). Only the two user-action paths call
+	/// this — inference (#158) and restoration set the mode without it.
+	private func noteUserChangedMode() {
+		(view.window?.windowController?.document as? Document)?.noteUserChangedMode(currentMode)
 	}
 	
 	func updateModeUI() {
@@ -467,6 +475,7 @@ class EditorViewController: NSViewController, NSTextViewDelegate {
 			removeMarkdownStyling()
 		}
 		updateModeUI()
+		noteUserChangedMode()
 	}
 	
 	func removeMarkdownStyling() {

--- a/Jot/Models/EditorMode.swift
+++ b/Jot/Models/EditorMode.swift
@@ -8,7 +8,9 @@
 import Foundation
 import UniformTypeIdentifiers
 
-enum EditorMode {
+/// Raw values are the serialization format of the view-settings extended
+/// attribute (#157) — renaming a case breaks reading existing files' xattrs.
+enum EditorMode: String {
 	case plainText
 	case markdown
 

--- a/JotTests/DocumentTests.swift
+++ b/JotTests/DocumentTests.swift
@@ -648,4 +648,133 @@ final class DocumentTests: XCTestCase {
         XCTAssertEqual(doc.text, "plain ascii")
     }
 
+    // MARK: - Per-document view settings (#157)
+
+    func testFileAttributesIncludeViewSettingsWhenOverrideSet() throws {
+        let doc = Document()
+        doc.modeOverride = .markdown
+
+        let attributes = try doc.fileAttributesToWrite(
+            to: URL(fileURLWithPath: "/tmp/ignored.txt"), ofType: "public.plain-text",
+            for: .saveOperation, originalContentsURL: nil)
+
+        let extended = try XCTUnwrap(attributes["NSFileExtendedAttributes"] as? [String: Any])
+        let data = try XCTUnwrap(extended[Document.viewSettingsAttributeName] as? Data)
+        let plist = try XCTUnwrap(
+            PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any])
+        XCTAssertEqual(plist["mode"] as? String, "markdown")
+    }
+
+    func testFileAttributesOmitViewSettingsWithoutOverride() throws {
+        let doc = Document()
+
+        let attributes = try doc.fileAttributesToWrite(
+            to: URL(fileURLWithPath: "/tmp/ignored.txt"), ofType: "public.plain-text",
+            for: .saveOperation, originalContentsURL: nil)
+
+        let extended = attributes["NSFileExtendedAttributes"] as? [String: Any]
+        XCTAssertNil(extended?[Document.viewSettingsAttributeName],
+                     "no explicit choice → no attribute — inference stays in charge")
+    }
+
+    /// The round trip the issue asks for: through writeSafely (which applies
+    /// fileAttributesToWrite as part of the safe-save), not just setxattr.
+    func testModeOverrideRoundTripsThroughRealSave() throws {
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("JotViewSettings_\(UUID().uuidString).txt")
+        defer { try? FileManager.default.removeItem(at: tempURL) }
+
+        let doc = Document()
+        doc.text = "content"
+        doc.modeOverride = .markdown
+        try doc.writeSafely(to: tempURL, ofType: "public.plain-text", for: .saveAsOperation)
+
+        let reread = Document()
+        try reread.read(from: tempURL, ofType: "public.plain-text")
+        XCTAssertEqual(reread.modeOverride, .markdown)
+        XCTAssertEqual(reread.initialEditorMode, .markdown,
+                       "the recorded choice beats the .txt inference")
+    }
+
+    func testModeOverrideReadFromExtendedAttribute() throws {
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("JotViewSettings_\(UUID().uuidString).txt")
+        defer { try? FileManager.default.removeItem(at: tempURL) }
+        try "content".write(to: tempURL, atomically: true, encoding: .utf8)
+
+        let value = try XCTUnwrap(Document.viewSettingsAttributeValue(mode: .markdown))
+        try value.withUnsafeBytes { buffer in
+            let result = setxattr(tempURL.path, Document.viewSettingsAttributeName,
+                                  buffer.baseAddress, buffer.count, 0, 0)
+            if result != 0 { throw POSIXError(.EIO) }
+        }
+
+        let doc = Document()
+        try doc.read(from: tempURL, ofType: "public.plain-text")
+        XCTAssertEqual(doc.modeOverride, .markdown)
+    }
+
+    func testGarbageViewSettingsAttributeIsIgnored() throws {
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("JotViewSettings_\(UUID().uuidString).txt")
+        defer { try? FileManager.default.removeItem(at: tempURL) }
+        try "content".write(to: tempURL, atomically: true, encoding: .utf8)
+
+        let garbage: [UInt8] = [0xDE, 0xAD, 0xBE, 0xEF]
+        setxattr(tempURL.path, Document.viewSettingsAttributeName, garbage, garbage.count, 0, 0)
+
+        let doc = Document()
+        try doc.read(from: tempURL, ofType: "public.plain-text")
+        XCTAssertNil(doc.modeOverride, "an unreadable attribute degrades to inference, never an error")
+        XCTAssertEqual(doc.text, "content")
+    }
+
+    func testInitialModeFallsThroughToInferenceWithoutOverride() {
+        let doc = Document()
+        doc.fileURL = URL(fileURLWithPath: "/tmp/notes.md")
+        XCTAssertEqual(doc.initialEditorMode, .markdown, ".md inference applies when no override")
+
+        doc.modeOverride = .plainText
+        XCTAssertEqual(doc.initialEditorMode, .plainText, "the explicit choice beats inference")
+    }
+
+    func testNoteUserChangedModeWritesAttributeWithoutDirtying() throws {
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("JotViewSettings_\(UUID().uuidString).txt")
+        defer { try? FileManager.default.removeItem(at: tempURL) }
+        try "content".write(to: tempURL, atomically: true, encoding: .utf8)
+
+        let doc = Document()
+        doc.fileURL = tempURL
+        doc.noteUserChangedMode(.markdown)
+
+        XCTAssertEqual(doc.modeOverride, .markdown)
+        XCTAssertFalse(doc.isDocumentEdited,
+                       "a view-setting change must not mark the document edited")
+
+        // On disk immediately — a crash before the next save loses nothing
+        let reread = Document()
+        try reread.read(from: tempURL, ofType: "public.plain-text")
+        XCTAssertEqual(reread.modeOverride, .markdown)
+    }
+
+    func testNoteUserChangedModeOnUntitledDocumentStaysInMemory() {
+        let doc = Document()
+        doc.noteUserChangedMode(.markdown)
+
+        XCTAssertEqual(doc.modeOverride, .markdown,
+                       "held in memory until the first save writes it via fileAttributesToWrite")
+        XCTAssertFalse(doc.isDocumentEdited)
+    }
+
+    func testDuplicateCarriesModeOverride() throws {
+        let doc = Document()
+        doc.text = "content"
+        doc.modeOverride = .markdown
+
+        let duplicated = try XCTUnwrap(doc.duplicate() as? Document)
+        defer { duplicated.close() }
+        XCTAssertEqual(duplicated.modeOverride, .markdown)
+    }
+
 }


### PR DESCRIPTION
## Summary

Phase 6 of `docs/file-handling-plan.md`, scoped per discussion to **mode only** (#224 tracks line numbers and word count, which need a control-surface decision first):

- **`com.brian.jot.view-settings` extended attribute** — a keyed binary plist (`{"mode": "markdown"}`) so #224's additions extend it without a format break. Read in the same `read(from url:)` peek as the encoding hint; applied in `makeWindowControllers` through the Phase 4 precedence chain: restoration → **override** → extension inference → default.
- **Overrides, not snapshots**: only the two explicit user actions (mode popup, toggle command) record a choice — inference and restoration never do. Once touched, the choice is always explicit and wins over inference (renaming `report.md` to `.txt` keeps your markdown choice).
- **Persistence is belt and braces**: `setxattr` immediately on the explicit change, plus re-application on every save via `fileAttributesToWrite`'s `NSFileExtendedAttributes` (the #194 mechanism) so the atomic safe-save swap can't strip it. Survives a crash before any save.
- **No change-count games**: the first design used `updateChangeCount(.changeDiscardable)`; the test caught it marking the document edited, and NSDocument.h confirms — "Discardable changes cause the document to be edited." A view toggle now touches nothing: no Edited state, no close prompt, no Versions entry (test-pinned).
- Untitled documents hold the override in memory until first save; `duplicate()` carries it; a garbage attribute degrades to inference, never an error.

## Tests

310 total (9 new): fileAttributesToWrite presence/absence, round trip through a real `writeSafely` (not just setxattr), setxattr read, garbage tolerance, override-beats-inference fall-through, no-dirtying on saved and untitled documents, duplication.

## Manual test suggestions

- Open a `.txt`, switch it to Markdown, close, reopen → opens in Markdown. `xattr -l file.txt` shows `com.brian.jot.view-settings`.
- Open a `.md` (opens Markdown by inference), switch to Plain Text, close, reopen → stays Plain Text.
- Toggling the mode on a clean saved document must NOT show the Edited state in the title bar.
- Edit content + toggle mode + Cmd-S → both persist (the save path re-applies the xattr).
- A never-touched document keeps following inference — `xattr -l` shows no view-settings attribute.
- Copy the file in Finder → the copy keeps the choice. Pipe it through git/upload → choice lost, falls back to inference (by design).

Closes #157.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015SvAwERh6dke6vSFmjNXVg
