### PR TITLE
fix: re-apply the editor mode after revert (#157 review)

### DIFF
--- a/Jot/App/Document.swift
+++ b/Jot/App/Document.swift
@@ -105,11 +105,18 @@ class Document: NSDocument {
 		// implementation funnels down to read(from:ofType:) with bare data
 		xattrEncodingHint = Self.encodingFromExtendedAttribute(at: url)
 		defer { xattrEncodingHint = nil }
-		// Assign-only-when-present, because revert also funnels through
-		// here: if the immediate setxattr in noteUserChangedMode failed
-		// (read-only volume, no-xattr filesystem), the in-memory override
-		// is still the user's explicit choice and revert must not erase
-		// it. On a fresh open both sides are nil, so nothing changes.
+		// Assign-only-when-present: a missing attribute never clears an
+		// explicit choice. One rule for all three callers of this path —
+		// fresh open (both sides nil, nothing changes), Revert to Saved
+		// (a failed immediate setxattr must not be compounded by revert
+		// erasing the in-memory choice), and the Versions browser's
+		// Restore. Mode persisting through Restore is the platform
+		// semantic, not an accident: NSFileVersion's replaceItem restores
+		// file content but leaves the live file's xattrs in place
+		// (verified empirically, 2026-08), so com.apple.TextEncoding
+		// survives a TextEdit restore the same way. Making Restore adopt
+		// the snapshot's view settings would mean fighting that machinery
+		// with restore-detection and attribute syncing — rejected.
 		if let onDisk = Self.modeOverrideFromExtendedAttribute(at: url) {
 			modeOverride = onDisk
 		}

--- a/Jot/App/Document.swift
+++ b/Jot/App/Document.swift
@@ -105,7 +105,14 @@ class Document: NSDocument {
 		// implementation funnels down to read(from:ofType:) with bare data
 		xattrEncodingHint = Self.encodingFromExtendedAttribute(at: url)
 		defer { xattrEncodingHint = nil }
-		modeOverride = Self.modeOverrideFromExtendedAttribute(at: url)
+		// Assign-only-when-present, because revert also funnels through
+		// here: if the immediate setxattr in noteUserChangedMode failed
+		// (read-only volume, no-xattr filesystem), the in-memory override
+		// is still the user's explicit choice and revert must not erase
+		// it. On a fresh open both sides are nil, so nothing changes.
+		if let onDisk = Self.modeOverrideFromExtendedAttribute(at: url) {
+			modeOverride = onDisk
+		}
 		try super.read(from: url, ofType: typeName)
 	}
 
@@ -224,8 +231,10 @@ class Document: NSDocument {
 	internal static let viewSettingsAttributeName = "com.brian.jot.view-settings"
 
 	/// Mode the editor should open with: the user's recorded choice, else
-	/// inference from the file type (#157, #158). Restoration state is
-	/// applied later and beats both.
+	/// inference from the file type (#157, #158). Applied on open (via
+	/// makeWindowControllers) and on revert; restoration state is applied
+	/// later on relaunch and beats both. A duplicate carries the override
+	/// in memory only until its first explicit save writes it (#228).
 	var initialEditorMode: EditorMode {
 		modeOverride ?? EditorMode.inferred(fromTypeIdentifier: fileType,
 											filenameExtension: fileURL?.pathExtension)
@@ -313,6 +322,11 @@ class Document: NSDocument {
 		// back into the editor -- without this the window keeps showing the
 		// old text and the next debounced sync re-overwrites the revert (#119).
 		if let viewController = windowControllers.first?.contentViewController as? EditorViewController {
+			// The reread also refreshed modeOverride from the file's xattr.
+			// Re-apply it before the text lands so the editor can't disagree
+			// with the model — a stale currentMode here would propagate back
+			// to the xattr on the next explicit toggle (review of #157).
+			viewController.applyInitialMode(initialEditorMode)
 			viewController.documentDidRevert(to: text)
 		}
 	}

--- a/JotTests/DocumentTests.swift
+++ b/JotTests/DocumentTests.swift
@@ -292,6 +292,56 @@ final class DocumentTests: XCTestCase {
                        "revert must reload the visible editor, not just the model")
     }
 
+    func testRevertReappliesModeFromExtendedAttribute() throws {
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("JotRevert_\(UUID().uuidString).txt")
+        defer { try? FileManager.default.removeItem(at: tempURL) }
+        try "content".write(to: tempURL, atomically: true, encoding: .utf8)
+
+        let doc = Document()
+        doc.fileURL = tempURL
+        doc.text = "content"
+        doc.makeWindowControllers()
+        defer { doc.close() }
+        guard let editor = doc.windowControllers.first?.contentViewController as? EditorViewController else {
+            XCTFail("expected an EditorViewController")
+            return
+        }
+        XCTAssertEqual(editor.currentMode, .plainText)
+
+        // Another window (or an earlier session) recorded a markdown choice
+        let value = try XCTUnwrap(Document.viewSettingsAttributeValue(mode: .markdown))
+        try value.withUnsafeBytes { buffer in
+            let result = setxattr(tempURL.path, Document.viewSettingsAttributeName,
+                                  buffer.baseAddress, buffer.count, 0, 0)
+            if result != 0 { throw POSIXError(.EIO) }
+        }
+
+        try doc.revert(toContentsOf: tempURL, ofType: "public.plain-text")
+
+        XCTAssertEqual(doc.modeOverride, .markdown)
+        XCTAssertEqual(editor.currentMode, .markdown,
+                       "revert must re-apply the mode, not just reload the text — a stale editor mode propagates back to the xattr on the next toggle")
+    }
+
+    func testRevertKeepsInMemoryOverrideWhenFileHasNoAttribute() throws {
+        // The setxattr in noteUserChangedMode can fail (read-only volume,
+        // no-xattr filesystem); the in-memory override is then the only
+        // record of the user's explicit choice and revert must not erase it
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("JotRevert_\(UUID().uuidString).txt")
+        defer { try? FileManager.default.removeItem(at: tempURL) }
+        try "content".write(to: tempURL, atomically: true, encoding: .utf8)
+
+        let doc = Document()
+        doc.fileURL = tempURL
+        doc.modeOverride = .markdown
+
+        try doc.revert(toContentsOf: tempURL, ofType: "public.plain-text")
+
+        XCTAssertEqual(doc.modeOverride, .markdown)
+    }
+
     // MARK: - Legacy unsaved-state migration (#121)
 
     func testMigrationRestoresLegacyDraftAsEditedDocument() throws {

--- a/JotTests/DocumentTests.swift
+++ b/JotTests/DocumentTests.swift
@@ -325,9 +325,12 @@ final class DocumentTests: XCTestCase {
     }
 
     func testRevertKeepsInMemoryOverrideWhenFileHasNoAttribute() throws {
-        // The setxattr in noteUserChangedMode can fail (read-only volume,
-        // no-xattr filesystem); the in-memory override is then the only
-        // record of the user's explicit choice and revert must not erase it
+        // A missing attribute never clears an explicit choice. This covers
+        // both the failed-setxattr case (read-only volume, no-xattr
+        // filesystem) and the Versions browser's Restore, where the
+        // platform itself keeps the live file's xattrs (replaceItem
+        // restores content, not metadata) — mode persists through a
+        // restore by design, matching TextEdit's encoding attribute
         let tempURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("JotRevert_\(UUID().uuidString).txt")
         defer { try? FileManager.default.removeItem(at: tempURL) }


### PR DESCRIPTION
## Summary

First of the two follow-up PRs from the post-milestone review (security / code quality / accessibility) of the File Handling milestone.

Fixes the review's top finding: **revert desynced the editor mode from the document model.** `revert(toContentsOf:)` re-read the view-settings xattr into `modeOverride`, but the editor's `currentMode` and popup were never re-applied — the window could show Plain Text while the model said Markdown, and the next explicit toggle would write the stale value to disk. Revert now calls `applyInitialMode(initialEditorMode)` before reloading the text — the same precedence entry point the open path uses.

Second, related hardening from the same finding: the xattr read in `read(from url:)` is now assign-only-when-present, so a revert cannot erase an in-memory override whose immediate `setxattr` had failed (read-only volume, no-xattr filesystem) — the in-memory value is the user's explicit choice and the only surviving record in that case. Fresh opens are unchanged (both sides nil).

`initialEditorMode`'s doc comment now states the per-path behavior honestly (open and revert apply it; restoration beats it on relaunch; a duplicate carries the override in memory until first save, #228) — the review flagged that the comments promised a cleaner precedence model than the code delivered.

## Tests

312 total (2 new): the exact desync scenario (xattr recorded by another session, revert, editor mode must follow) and the override-preservation-on-revert case.

## Manual test

Open a `.txt`, switch it to Markdown (xattr written), then File > Revert to Saved: the window should stay in Markdown with the popup agreeing. For the fuller scenario: open the same file, `xattr -w` a different mode from Terminal, revert, and watch the mode follow the attribute.
