### PR TITLE
chore: hardening batch from the post-milestone review

### DIFF
--- a/Jot/App/Document.swift
+++ b/Jot/App/Document.swift
@@ -6,9 +6,12 @@
 //
 
 import Cocoa
+import os
 import os.signpost
 
 class Document: NSDocument {
+	private static let log = Logger(subsystem: "com.brian.jot", category: "document")
+
 	// SAFETY: NSDocument calls read/write overrides on the main thread for
 	// non-concurrent document types. This class does not opt into
 	// canConcurrentlyReadDocuments(ofType:), so all access is serialized
@@ -123,6 +126,13 @@ class Document: NSDocument {
 		// Detecting from the raw bytes works on both; save puts the bytes
 		// back either way (#194).
 		hadUTF8BOM = encoding == .utf8 && data.starts(with: [0xEF, 0xBB, 0xBF])
+		// Deliberately independent of the flag above: the strip removes a
+		// decoded U+FEFF under any encoding (UTF-16's BOM also decodes to
+		// one), while the flag is UTF-8-only because only UTF-8 needs the
+		// bytes manually re-emitted on save. A UTF-8 BOM read under a
+		// wrong non-UTF-8 hint decodes as ordinary mojibake characters,
+		// stays in the buffer, and round-trips byte-for-byte — preserved,
+		// not stripped, which is the safe outcome.
 		if decoded.hasPrefix("\u{FEFF}") {
 			decoded.removeFirst()
 		}
@@ -235,28 +245,43 @@ class Document: NSDocument {
 	/// Writes the attribute to disk immediately instead of touching the
 	/// change count: NSDocument.h is explicit that even "discardable"
 	/// changes mark the document edited, and a view toggle must not show
-	/// an Edited state or create Versions entries. The immediate write
-	/// can't be lost to a later safe-save swap because every save also
-	/// re-applies the attribute via fileAttributesToWrite; untitled
-	/// documents carry the override in memory until their first save.
+	/// an Edited state or create Versions entries. Every save re-applies
+	/// the attribute via fileAttributesToWrite, so a failed immediate
+	/// write (read-only volume, no-xattr filesystem) still reaches disk
+	/// at the next save — the override is lost only if the document is
+	/// never saved again. Untitled documents carry it in memory until
+	/// their first save.
 	func noteUserChangedMode(_ mode: EditorMode) {
 		modeOverride = mode
 		guard let path = fileURL?.path,
 			  let value = Self.viewSettingsAttributeValue(mode: mode) else { return }
-		_ = value.withUnsafeBytes { buffer in
+		let result = value.withUnsafeBytes { buffer in
 			setxattr(path, Self.viewSettingsAttributeName, buffer.baseAddress, buffer.count, 0, 0)
+		}
+		if result != 0 {
+			// "Why doesn't my mode stick on my NAS" should cost five
+			// minutes in Console, not an afternoon (review of #157)
+			Self.log.info("view-settings xattr write failed (errno \(errno)); override held in memory until the next save")
 		}
 	}
 
 	/// The attribute is a keyed plist rather than a bare value so the
 	/// planned line-numbers and word-count overrides (#224) extend it
-	/// without a format break.
+	/// without a format break. Note for #224: getxattr fails outright
+	/// (ERANGE) if the attribute outgrows the fixed buffer — 4096 is
+	/// generous for a mode string, but growing the payload means moving
+	/// to the size-then-read two-call idiom.
 	private static func modeOverrideFromExtendedAttribute(at url: URL) -> EditorMode? {
 		var buffer = [UInt8](repeating: 0, count: 4096)
 		let length = getxattr(url.path, viewSettingsAttributeName, &buffer, buffer.count, 0, 0)
 		guard length > 0 else { return nil }
+		// The app only ever writes binary plists; rejecting the XML form
+		// keeps attacker-controllable bytes away from the much larger XML
+		// parser surface (post-#157 security review)
+		var format = PropertyListSerialization.PropertyListFormat.binary
 		guard let plist = try? PropertyListSerialization.propertyList(
-				from: Data(buffer[0..<length]), format: nil) as? [String: Any],
+				from: Data(buffer[0..<length]), options: [], format: &format) as? [String: Any],
+			  format == .binary,
 			  let rawMode = plist["mode"] as? String else {
 			return nil
 		}
@@ -612,7 +637,11 @@ private final class EncodingRecoveryAttempter: NSObject {
 								  delegate: Any?, didRecoverSelector: Selector?,
 								  contextInfo: UnsafeMutableRawPointer?) {
 		let didRecover = attemptRecovery(fromError: error, optionIndex: recoveryOptionIndex)
-		guard let delegate = delegate as? NSObject, let didRecoverSelector else { return }
+		guard let delegate = delegate as? NSObject, let didRecoverSelector,
+			  // method(for:) returns a forwarding IMP for unimplemented
+			  // selectors, which the cast below would then call with the
+			  // wrong signature — refuse rather than crash
+			  delegate.responds(to: didRecoverSelector) else { return }
 		// The callback signature is (didRecover:contextInfo:) — not
 		// expressible through performSelector, hence the IMP cast
 		typealias Callback = @convention(c) (NSObject, Selector, Bool, UnsafeMutableRawPointer?) -> Void

--- a/Jot/Editor/EditorViewController.swift
+++ b/Jot/Editor/EditorViewController.swift
@@ -46,6 +46,12 @@ class EditorViewController: NSViewController, NSTextViewDelegate {
 		label.font = .systemFont(ofSize: NSFont.smallSystemFontSize)
 		label.textColor = .secondaryLabelColor
 		label.translatesAutoresizingMaskIntoConstraints = false
+		// labelWithString: configures the cell to hard-clip mid-character;
+		// in a narrow window "CP1252 · CRLF" became "CP12" with no cue
+		// anything was missing (post-milestone a11y review). Truncate with
+		// an ellipsis and let a tooltip recover the full value.
+		label.lineBreakMode = .byTruncatingTail
+		label.allowsExpansionToolTips = true
 		label.setAccessibilityLabel("File encoding and line endings")
 		return label
 	}()
@@ -124,6 +130,11 @@ class EditorViewController: NSViewController, NSTextViewDelegate {
 			return
 		}
 		fileInfoLabel.stringValue = "\(document.encodingDisplayName) · \(document.lineEnding.rawValue)"
+		// Spoken form without the separator dot: VoiceOver either skips
+		// "·" (running the tokens together) or reads "middle dot",
+		// depending on punctuation verbosity — both worse than words
+		fileInfoLabel.setAccessibilityLabel(
+			"File encoding \(document.encodingDisplayName), \(document.lineEnding.rawValue) line endings")
 	}
 
 	@objc private func fontConfigurationDidChange(_ notification: Notification) {
@@ -436,10 +447,15 @@ class EditorViewController: NSViewController, NSTextViewDelegate {
 		let modeTitle = (currentMode == .markdown) ? "Markdown" : "Plain Text"
 		modePopUpButton.selectItem(withTitle: modeTitle)
 
+		// High priority: after a popup selection or menu command VoiceOver
+		// is already speaking, and it coalesces medium-priority (default)
+		// announcements away — the same trap the recovery announcement in
+		// Document documents (post-milestone a11y review)
 		NSAccessibility.post(
 			element: modePopUpButton as Any,
 			notification: .announcementRequested,
-			userInfo: [.announcement: "Switched to \(modeTitle) mode"]
+			userInfo: [.announcement: "Switched to \(modeTitle) mode",
+					   .priority: NSAccessibilityPriorityLevel.high.rawValue]
 		)
 	}
 	
@@ -797,7 +813,8 @@ class EditorViewController: NSViewController, NSTextViewDelegate {
 		NSAccessibility.post(
 			element: textView as Any,
 			notification: .announcementRequested,
-			userInfo: [.announcement: "Reverted to last saved version"]
+			userInfo: [.announcement: "Reverted to last saved version",
+					   .priority: NSAccessibilityPriorityLevel.high.rawValue]
 		)
 	}
 
@@ -846,7 +863,8 @@ class EditorViewController: NSViewController, NSTextViewDelegate {
 		NSAccessibility.post(
 			element: textView as Any,
 			notification: .announcementRequested,
-			userInfo: [.announcement: message]
+			userInfo: [.announcement: message,
+					   .priority: NSAccessibilityPriorityLevel.high.rawValue]
 		)
 	}
 }

--- a/JotTests/DocumentTests.swift
+++ b/JotTests/DocumentTests.swift
@@ -768,6 +768,9 @@ final class DocumentTests: XCTestCase {
     }
 
     func testDuplicateCarriesModeOverride() throws {
+        // In memory only: the duplicate's own autosave runs before the
+        // override is assigned, so disk gets it at the first explicit
+        // save (#228 tracks whether that should change)
         let doc = Document()
         doc.text = "content"
         doc.modeOverride = .markdown
@@ -775,6 +778,59 @@ final class DocumentTests: XCTestCase {
         let duplicated = try XCTUnwrap(doc.duplicate() as? Document)
         defer { duplicated.close() }
         XCTAssertEqual(duplicated.modeOverride, .markdown)
+    }
+
+    func testNoteUserChangedModeOnMissingFileKeepsOverride() {
+        // The file was moved or deleted in Finder while the window stayed
+        // open; setxattr fails with ENOENT and must not crash or lose the
+        // in-memory choice
+        let doc = Document()
+        doc.fileURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("JotGone_\(UUID().uuidString).txt")
+
+        doc.noteUserChangedMode(.markdown)
+
+        XCTAssertEqual(doc.modeOverride, .markdown)
+    }
+
+    // MARK: - Review-pinned round trips (#194 follow-up)
+
+    /// The encoding tests stop at data(ofType:); this one verifies the
+    /// com.apple.TextEncoding xattr actually lands on a real saved file.
+    func testTextEncodingAttributeLandsOnDiskThroughRealSave() throws {
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("JotEncoding_\(UUID().uuidString).txt")
+        defer { try? FileManager.default.removeItem(at: tempURL) }
+
+        let doc = Document()
+        doc.text = "smart \u{201C}quotes\u{201D}"
+        doc.readEncoding = .windowsCP1252
+        try doc.writeSafely(to: tempURL, ofType: "public.plain-text", for: .saveAsOperation)
+
+        var buffer = [UInt8](repeating: 0, count: 256)
+        let length = getxattr(tempURL.path, "com.apple.TextEncoding", &buffer, buffer.count, 0, 0)
+        XCTAssertGreaterThan(length, 0, "the attribute must survive the safe-save")
+        XCTAssertEqual(String(bytes: buffer[0..<max(length, 0)], encoding: .utf8), "windows-1252;1280")
+    }
+
+    /// Correct today and fragile: a BOM-only file must open as empty text
+    /// and save back as exactly its three bytes.
+    func testBOMOnlyFileRoundTrips() throws {
+        let doc = Document()
+        try doc.read(from: Data([0xEF, 0xBB, 0xBF]), ofType: "public.plain-text")
+
+        XCTAssertEqual(doc.text, "")
+        XCTAssertTrue(doc.hadUTF8BOM)
+        XCTAssertEqual(Array(try doc.data(ofType: "public.plain-text")), [0xEF, 0xBB, 0xBF])
+    }
+
+    func testEmptyFileRoundTripsWithoutGainingBOM() throws {
+        let doc = Document()
+        try doc.read(from: Data(), ofType: "public.plain-text")
+
+        XCTAssertEqual(doc.text, "")
+        XCTAssertFalse(doc.hadUTF8BOM)
+        XCTAssertEqual(try doc.data(ofType: "public.plain-text").count, 0)
     }
 
 }


### PR DESCRIPTION
## Summary

Second follow-up PR from the post-milestone review (companion to #231). All items are the small, no-design-decision fixes; the ones needing decisions are filed as #226-#230.

**Security (defense-in-depth — the review confirmed the current code is correct):**
- `responds(to:)` guard before the recovery attempter's IMP cast (`method(for:)` returns a forwarding IMP for unimplemented selectors).
- View-settings plist read pinned to binary format — the app only writes binary, so nothing is lost, and attacker-controllable xattr bytes stay away from the much larger XML parser surface.

**Robustness:**
- `noteUserChangedMode` logs `setxattr` failures via `Logger` instead of silently discarding the result ("why doesn't my mode stick on my NAS" should cost five minutes in Console, not an afternoon). Its doc comment now states the real guarantee instead of overclaiming.
- Comment for #224: the fixed 4096-byte getxattr buffer fails outright (ERANGE) if the attribute outgrows it — growing the payload means the size-then-read idiom.

**Accessibility (from the a11y review — no blockers found, these are the polish items):**
- All announcements post at `.priority: high`. VoiceOver coalesces medium-priority (default) announcements away while already speaking — after a popup selection or menu command it always is. The recovery announcement had this right and documented; the newer call sites (mode switch, revert, checklist feedback) reintroduced the trap.
- The file-info label truncates with an ellipsis + expansion tooltip instead of hard-clipping ("CP12" in narrow windows), and carries a spoken-friendly accessibility label ("File encoding CP1252, CRLF line endings") instead of the "·" separator soup.

**Comment honesty:**
- The deliberate asymmetry between `hadUTF8BOM` (raw-byte, UTF-8-only) and the encoding-independent U+FEFF strip is now explained — the review found the correct behavior looked accidental.
- `testDuplicateCarriesModeOverride` is annotated as pinning the in-memory copy only (#228).

## Tests

314 total (4 new), pinning behavior the review verified as correct but fragile: `com.apple.TextEncoding` landing on disk through a real `writeSafely`, `noteUserChangedMode` on a deleted file (no crash, override retained), BOM-only files round-tripping to exactly three bytes, empty files staying empty.

## Manual test suggestions

- VoiceOver on: toggle mode via the popup — "Switched to Markdown mode" should now be spoken reliably, not intermittently.
- Narrow the window until the status label runs out of room: ellipsis instead of a hard clip, hover for the full value.
- (Optional) `chmod 444` a file's parent dir scenario is awkward to set up; the Console logging path is covered by the deleted-file test.
