### PR TITLE
feat: add File > New from Template backed by a Templates folder (#161)

### DIFF
--- a/Jot/App/AppDelegate.swift
+++ b/Jot/App/AppDelegate.swift
@@ -16,7 +16,12 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
 	var helpWindowController: HelpWindowController?
 	var previewWindowController: MarkdownPreviewWindowController?
 	var acknowledgementsWindowController: AcknowledgementsWindowController?
-	
+
+	/// The File > New from Template submenu (#161), populated on demand
+	/// from the Templates folder by templateMenuSource.
+	@IBOutlet weak var newFromTemplateMenu: NSMenu!
+	var templateMenuSource: FolderMenuSource?
+
 	@IBAction func showAboutWindow(_ sender: Any) {
 		if aboutWindowController == nil {
 			aboutWindowController = AboutWindowControllerProgrammatic()
@@ -93,6 +98,30 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
 		}
 	}
 	
+	// MARK: - New from Template (#161)
+
+	@IBAction func newDocumentFromTemplate(_ sender: Any?) {
+		guard let url = (sender as? NSMenuItem)?.representedObject as? URL else { return }
+		do {
+			try Document.makeUntitledDocument(fromTemplateAt: url)
+		} catch {
+			NSApp.presentError(error)
+		}
+	}
+
+	/// Opens the Templates folder in Finder, creating it first if needed —
+	/// the only place the folder is ever created.
+	@IBAction func openTemplatesFolder(_ sender: Any?) {
+		guard let folder = templateMenuSource?.folder else { return }
+		do {
+			try FileManager.default.createDirectory(at: folder, withIntermediateDirectories: true)
+		} catch {
+			NSApp.presentError(error)
+			return
+		}
+		NSWorkspace.shared.open(folder)
+	}
+
 	@IBAction func openAcknowledgements(_ sender: Any) {
 		if acknowledgementsWindowController == nil {
 			acknowledgementsWindowController = AcknowledgementsWindowController()
@@ -120,6 +149,19 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
 		// crash-recovery system. NSDocument autosave owns crash recovery
 		// now (#121), so there is no terminate-time state saving.
 		Document.migrateLegacyUnsavedStates()
+
+		// The submenu contents live in the Templates folder, not the
+		// storyboard — the delegate rebuilds them on every menu open (#161).
+		let source = FolderMenuSource(
+			folder: FolderMenuSource.applicationSupportFolder(named: "Templates"),
+			fileExtensions: ["txt", "md"],
+			emptyTitle: "No Templates",
+			selectionAction: #selector(newDocumentFromTemplate(_:)),
+			openFolderTitle: "Open Templates Folder",
+			openFolderAction: #selector(openTemplatesFolder(_:)),
+			target: self)
+		templateMenuSource = source
+		newFromTemplateMenu?.delegate = source
 	}
 
 	func applicationSupportsSecureRestorableState(_ app: NSApplication) -> Bool {

--- a/Jot/App/Document.swift
+++ b/Jot/App/Document.swift
@@ -422,6 +422,34 @@ class Document: NSDocument {
 		return newDocument
 	}
 
+	// MARK: - New from Template (#161)
+
+	/// Untitled draft seeded from a template file. Untitled on purpose:
+	/// the template is stationery — the new document must never point
+	/// back at it.
+	@discardableResult
+	static func makeUntitledDocument(fromTemplateAt url: URL) throws -> Document {
+		// Templates are files the user authors in Jot, so UTF-8 is the
+		// contract; a non-UTF-8 file surfaces as a read error.
+		let raw = try String(contentsOf: url, encoding: .utf8)
+
+		let doc = Document()
+		doc.text = LineEnding.normalizeToLF(raw)
+		// fileType rather than modeOverride: the override is the user's
+		// explicit choice and is persisted to the view-settings xattr on
+		// save (#157). The type only steers initialEditorMode's inference.
+		if EditorMode.inferred(fromTypeIdentifier: nil, filenameExtension: url.pathExtension) == .markdown {
+			doc.fileType = "net.daringfireball.markdown"
+		}
+		// Mark edited so the draft participates in NSDocument autosave
+		// and closing the window prompts to save (#120)
+		doc.updateChangeCount(.changeDone)
+		NSDocumentController.shared.addDocument(doc)
+		doc.makeWindowControllers()
+		doc.showWindows()
+		return doc
+	}
+
 	// MARK: - Legacy unsaved-state migration
 
 	// Jot 1.0.6-1.0.8 had a hand-rolled crash-recovery system that wrote

--- a/Jot/Models/FolderMenuSource.swift
+++ b/Jot/Models/FolderMenuSource.swift
@@ -1,0 +1,108 @@
+//
+//  FolderMenuSource.swift
+//  Jot
+//
+//  Created on 8/17/26.
+//
+//  Fills a submenu from the plain-text files of a folder (#161,
+//  the BBEdit-stationery pattern): the file system is the management
+//  UI, the menu is just a live view of the folder. Configuration-
+//  driven so Insert Snippet (#162) is a second instance of this
+//  class, not a second class.
+//
+
+import Cocoa
+
+@MainActor
+final class FolderMenuSource: NSObject, NSMenuDelegate {
+
+	/// The folder whose files become menu items. An instance property
+	/// so tests point an instance at a temporary directory. A nil or
+	/// missing folder reads as empty — it is only created on demand by
+	/// the "Open … Folder" action, never during a menu scan.
+	var folder: URL?
+
+	private let fileExtensions: Set<String>
+	private let emptyTitle: String
+	private let selectionAction: Selector
+	private let openFolderTitle: String
+	private let openFolderAction: Selector
+	private weak var target: AnyObject?
+
+	/// - Parameter fileExtensions: lowercase, without the dot.
+	init(folder: URL?,
+	     fileExtensions: Set<String>,
+	     emptyTitle: String,
+	     selectionAction: Selector,
+	     openFolderTitle: String,
+	     openFolderAction: Selector,
+	     target: AnyObject) {
+		self.folder = folder
+		self.fileExtensions = fileExtensions
+		self.emptyTitle = emptyTitle
+		self.selectionAction = selectionAction
+		self.openFolderTitle = openFolderTitle
+		self.openFolderAction = openFolderAction
+		self.target = target
+	}
+
+	/// App Support/Jot/<name> — the same container-relative resolution
+	/// as Document.unsavedStatesFolder.
+	static func applicationSupportFolder(named name: String) -> URL? {
+		guard let support = try? FileManager.default.url(for: .applicationSupportDirectory,
+		                                                 in: .userDomainMask,
+		                                                 appropriateFor: nil,
+		                                                 create: false) else {
+			return nil
+		}
+		return support.appendingPathComponent("Jot/\(name)", isDirectory: true)
+	}
+
+	/// Visible files with a matching extension, in Finder order.
+	func files() -> [URL] {
+		guard let folder,
+		      let contents = try? FileManager.default.contentsOfDirectory(at: folder,
+		                                                                  includingPropertiesForKeys: nil,
+		                                                                  options: [.skipsHiddenFiles]) else {
+			return []
+		}
+		return contents
+			.filter { fileExtensions.contains($0.pathExtension.lowercased()) }
+			.sorted { $0.lastPathComponent.localizedStandardCompare($1.lastPathComponent) == .orderedAscending }
+	}
+
+	// MARK: - NSMenuDelegate
+
+	func menuNeedsUpdate(_ menu: NSMenu) {
+		menu.removeAllItems()
+
+		let files = files()
+		if files.isEmpty {
+			// nil action leaves the item disabled via autoenablesItems.
+			menu.addItem(NSMenuItem(title: emptyTitle, action: nil, keyEquivalent: ""))
+		}
+		for url in files {
+			let item = NSMenuItem(title: url.deletingPathExtension().lastPathComponent,
+			                      action: selectionAction,
+			                      keyEquivalent: "")
+			item.target = target
+			item.representedObject = url
+			menu.addItem(item)
+		}
+
+		menu.addItem(.separator())
+		let open = NSMenuItem(title: openFolderTitle, action: openFolderAction, keyEquivalent: "")
+		open.target = target
+		menu.addItem(open)
+	}
+
+	/// No dynamic item ever has a key equivalent. Without this, AppKit
+	/// falls back to menuNeedsUpdate — a folder scan — on every Cmd-key
+	/// press during key-equivalent resolution.
+	func menuHasKeyEquivalent(_ menu: NSMenu,
+	                          for event: NSEvent,
+	                          target: AutoreleasingUnsafeMutablePointer<AnyObject?>,
+	                          action: UnsafeMutablePointer<Selector?>) -> Bool {
+		return false
+	}
+}

--- a/Jot/Resources/Base.lproj/Main.storyboard
+++ b/Jot/Resources/Base.lproj/Main.storyboard
@@ -70,6 +70,10 @@
                                                 <action selector="newDocument:" target="Ady-hI-5gd" id="4Si-XN-c54"/>
                                             </connections>
                                         </menuItem>
+                                        <menuItem title="New from Template" id="Tpl-mi-161">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="New from Template" id="Tpl-mn-161"/>
+                                        </menuItem>
                                         <menuItem title="Open…" keyEquivalent="o" id="IAo-SY-fd9">
                                             <connections>
                                                 <action selector="openDocument:" target="Ady-hI-5gd" id="bVn-NM-KNZ"/>
@@ -767,7 +771,11 @@
                         <outlet property="delegate" destination="Voe-Tx-rLC" id="PrD-fu-P6m"/>
                     </connections>
                 </application>
-                <customObject id="Voe-Tx-rLC" customClass="AppDelegate" customModule="Jot" customModuleProvider="target"/>
+                <customObject id="Voe-Tx-rLC" customClass="AppDelegate" customModule="Jot" customModuleProvider="target">
+                    <connections>
+                        <outlet property="newFromTemplateMenu" destination="Tpl-mn-161" id="Tpl-ol-161"/>
+                    </connections>
+                </customObject>
                 <customObject id="YLy-65-1bz" customClass="NSFontManager"/>
                 <customObject id="Ady-hI-5gd" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
                 <containerView id="pzB-8E-oDV">

--- a/JotTests/DocumentTests.swift
+++ b/JotTests/DocumentTests.swift
@@ -345,6 +345,74 @@ final class DocumentTests: XCTestCase {
         XCTAssertEqual(doc.modeOverride, .markdown)
     }
 
+    // MARK: - New from Template (#161)
+
+    /// Runs `body` with a fresh temp directory that is removed afterward.
+    private func withTemplateFolder(_ body: (URL) throws -> Void) throws {
+        let tempFolder = FileManager.default.temporaryDirectory
+            .appendingPathComponent("JotTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempFolder, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempFolder) }
+        try body(tempFolder)
+    }
+
+    func testTemplateCreatesEditedUntitledDocument() throws {
+        try withTemplateFolder { folder in
+            let marker = "template-\(UUID().uuidString)"
+            let templateURL = folder.appendingPathComponent("Meeting Notes.txt")
+            try marker.write(to: templateURL, atomically: true, encoding: .utf8)
+
+            let doc = try Document.makeUntitledDocument(fromTemplateAt: templateURL)
+            defer { doc.close() }
+
+            XCTAssertTrue(NSDocumentController.shared.documents.contains(doc))
+            XCTAssertEqual(doc.text, marker)
+            XCTAssertTrue(doc.isDocumentEdited,
+                          "a template draft must be marked edited so autosave and close prompts apply")
+            XCTAssertNil(doc.fileURL, "the new document must not point back at the template file")
+            XCTAssertEqual(doc.initialEditorMode, .plainText)
+        }
+    }
+
+    func testMarkdownTemplateOpensInMarkdownMode() throws {
+        try withTemplateFolder { folder in
+            let templateURL = folder.appendingPathComponent("Blog Post.md")
+            try "# Title".write(to: templateURL, atomically: true, encoding: .utf8)
+
+            let doc = try Document.makeUntitledDocument(fromTemplateAt: templateURL)
+            defer { doc.close() }
+
+            XCTAssertEqual(doc.initialEditorMode, .markdown)
+            XCTAssertNil(doc.modeOverride,
+                         "mode comes from fileType inference; the override is reserved for the user's explicit choice (#157)")
+        }
+    }
+
+    func testTemplateWithCRLFIsNormalizedToLF() throws {
+        try withTemplateFolder { folder in
+            let templateURL = folder.appendingPathComponent("Windows.txt")
+            try "one\r\ntwo\r\nthree".write(to: templateURL, atomically: true, encoding: .utf8)
+
+            let doc = try Document.makeUntitledDocument(fromTemplateAt: templateURL)
+            defer { doc.close() }
+
+            XCTAssertEqual(doc.text, "one\ntwo\nthree")
+        }
+    }
+
+    func testNonUTF8TemplateThrowsAndAddsNoDocument() throws {
+        try withTemplateFolder { folder in
+            let templateURL = folder.appendingPathComponent("Latin1.txt")
+            // "café" in ISO Latin-1 — 0xE9 is not valid UTF-8
+            try Data([0x63, 0x61, 0x66, 0xE9]).write(to: templateURL)
+
+            let countBefore = NSDocumentController.shared.documents.count
+
+            XCTAssertThrowsError(try Document.makeUntitledDocument(fromTemplateAt: templateURL))
+            XCTAssertEqual(NSDocumentController.shared.documents.count, countBefore)
+        }
+    }
+
     // MARK: - Legacy unsaved-state migration (#121)
 
     func testMigrationRestoresLegacyDraftAsEditedDocument() throws {

--- a/JotTests/FolderMenuSourceTests.swift
+++ b/JotTests/FolderMenuSourceTests.swift
@@ -1,0 +1,155 @@
+//
+//  FolderMenuSourceTests.swift
+//  JotTests
+//
+//  Tests for the folder-backed dynamic submenu behind
+//  File > New from Template (#161).
+//
+
+import XCTest
+@testable import Jot
+
+@MainActor
+final class FolderMenuSourceTests: XCTestCase {
+
+    /// Dummy targets for the menu item actions; the tests only assert the
+    /// wiring, never fire the selectors.
+    @objc private func selectItem(_ sender: Any?) {}
+    @objc private func openFolder(_ sender: Any?) {}
+
+    private func makeSource(folder: URL?) -> FolderMenuSource {
+        FolderMenuSource(folder: folder,
+                         fileExtensions: ["txt", "md"],
+                         emptyTitle: "No Templates",
+                         selectionAction: #selector(selectItem(_:)),
+                         openFolderTitle: "Open Templates Folder",
+                         openFolderAction: #selector(openFolder(_:)),
+                         target: self)
+    }
+
+    /// Runs `body` with a fresh temp directory that is removed afterward.
+    private func withTempFolder(_ body: (URL) throws -> Void) throws {
+        let tempFolder = FileManager.default.temporaryDirectory
+            .appendingPathComponent("JotTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempFolder, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempFolder) }
+        try body(tempFolder)
+    }
+
+    private func createFile(_ name: String, in folder: URL) throws {
+        try "content".write(to: folder.appendingPathComponent(name), atomically: true, encoding: .utf8)
+    }
+
+    // MARK: - files()
+
+    func testFilesIncludesMatchingExtensionsOnly() throws {
+        try withTempFolder { folder in
+            try createFile("Notes.txt", in: folder)
+            try createFile("Post.md", in: folder)
+            try createFile("Scan.pdf", in: folder)
+
+            let names = makeSource(folder: folder).files().map { $0.lastPathComponent }
+
+            XCTAssertEqual(Set(names), ["Notes.txt", "Post.md"])
+        }
+    }
+
+    func testFilesMatchesExtensionsCaseInsensitively() throws {
+        try withTempFolder { folder in
+            try createFile("NOTES.TXT", in: folder)
+
+            let names = makeSource(folder: folder).files().map { $0.lastPathComponent }
+
+            XCTAssertEqual(names, ["NOTES.TXT"])
+        }
+    }
+
+    func testFilesSkipsHiddenFiles() throws {
+        try withTempFolder { folder in
+            try createFile(".hidden.txt", in: folder)
+            try createFile("Visible.txt", in: folder)
+
+            let names = makeSource(folder: folder).files().map { $0.lastPathComponent }
+
+            XCTAssertEqual(names, ["Visible.txt"])
+        }
+    }
+
+    func testFilesSortsLikeFinder() throws {
+        try withTempFolder { folder in
+            try createFile("Template 10.txt", in: folder)
+            try createFile("Template 2.txt", in: folder)
+            try createFile("Agenda.md", in: folder)
+
+            let names = makeSource(folder: folder).files().map { $0.lastPathComponent }
+
+            // localizedStandardCompare puts 2 before 10
+            XCTAssertEqual(names, ["Agenda.md", "Template 2.txt", "Template 10.txt"])
+        }
+    }
+
+    func testFilesEmptyForMissingFolder() {
+        let missing = FileManager.default.temporaryDirectory
+            .appendingPathComponent("JotTests-missing-\(UUID().uuidString)", isDirectory: true)
+
+        XCTAssertEqual(makeSource(folder: missing).files(), [])
+    }
+
+    func testFilesEmptyForNilFolder() {
+        XCTAssertEqual(makeSource(folder: nil).files(), [])
+    }
+
+    // MARK: - menuNeedsUpdate
+
+    func testMenuListsTemplatesWithoutExtensions() throws {
+        try withTempFolder { folder in
+            try createFile("Meeting Notes.txt", in: folder)
+            try createFile("Blog Post.md", in: folder)
+            let source = makeSource(folder: folder)
+            let menu = NSMenu()
+
+            source.menuNeedsUpdate(menu)
+
+            // 2 templates + separator + open item
+            XCTAssertEqual(menu.items.count, 4)
+            XCTAssertEqual(menu.items[0].title, "Blog Post")
+            XCTAssertEqual(menu.items[1].title, "Meeting Notes")
+            XCTAssertEqual(menu.items[0].representedObject as? URL,
+                           folder.appendingPathComponent("Blog Post.md"))
+            XCTAssertEqual(menu.items[0].action, #selector(selectItem(_:)))
+            XCTAssertTrue(menu.items[0].target === self)
+            XCTAssertTrue(menu.items[2].isSeparatorItem)
+            XCTAssertEqual(menu.items[3].title, "Open Templates Folder")
+            XCTAssertEqual(menu.items[3].action, #selector(openFolder(_:)))
+        }
+    }
+
+    func testMenuShowsDisabledEmptyStateWhenFolderIsEmpty() throws {
+        try withTempFolder { folder in
+            let source = makeSource(folder: folder)
+            let menu = NSMenu()
+
+            source.menuNeedsUpdate(menu)
+
+            XCTAssertEqual(menu.items.count, 3)
+            XCTAssertEqual(menu.items[0].title, "No Templates")
+            // nil action leaves the item disabled via autoenablesItems
+            XCTAssertNil(menu.items[0].action)
+            XCTAssertTrue(menu.items[1].isSeparatorItem)
+            XCTAssertEqual(menu.items[2].title, "Open Templates Folder")
+        }
+    }
+
+    func testMenuRebuildDoesNotAccumulateItems() throws {
+        try withTempFolder { folder in
+            try createFile("Notes.txt", in: folder)
+            let source = makeSource(folder: folder)
+            let menu = NSMenu()
+
+            source.menuNeedsUpdate(menu)
+            source.menuNeedsUpdate(menu)
+
+            XCTAssertEqual(menu.items.count, 3)
+        }
+    }
+}


### PR DESCRIPTION
Closes #161. First feature of the Content and Capture milestone.

## What this adds

- **File > New from Template** submenu, rebuilt from `Application Support/Jot/Templates` on every menu open (BBEdit stationery pattern — the file system is the management UI). Template name = filename without extension, Finder-style sort, .txt/.md only.
- **Open Templates Folder** item inside the submenu (after a separator); the only place the folder is created.
- Empty state: disabled "No Templates" placeholder so the feature stays discoverable.
- Choosing a template creates an **edited untitled document** seeded from the file. A .md template opens in markdown mode via `fileType` inference (#158); `modeOverride` stays untouched so no view-settings xattr (#157) is written on the template's behalf.

## Design notes

- `FolderMenuSource` is configuration-driven (folder, extensions, titles, actions) so #162 Insert Snippet becomes a second instance of the same class — the shared mechanism from docs/issue-clusters.md, built once.
- `menuHasKeyEquivalent` returns false so AppKit doesn't run the folder scan on every Cmd-key press during key-equivalent resolution.
- Templates are read as UTF-8 only and normalized to LF; a non-UTF-8 file surfaces as a presented error.
- Follow-up filed: #233 (Create New Template… affordance).

## Testing

- 13 new unit tests: 9 for `FolderMenuSource` (filtering, hidden files, case-insensitive extensions, Finder sort, empty/missing/nil folder, menu building, rebuild idempotence) and 4 for `Document.makeUntitledDocument(fromTemplateAt:)` (edited untitled doc, markdown mode, CRLF normalization, non-UTF-8 rejection).
- Full suite green locally; manual pass done (fresh empty state, folder creation, live menu refresh, both modes, save panel behavior, no stray xattr, Cmd-key latency, non-UTF-8 error).

Generated with [Claude Code](https://claude.com/claude-code)
