### PR TITLE
feat: add "New Jot Note from Selection" system service (#149)

### DIFF
--- a/Jot/App/AppDelegate.swift
+++ b/Jot/App/AppDelegate.swift
@@ -126,6 +126,22 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
 		openInFinderCreatingIfNeeded(snippetMenuSource?.folder)
 	}
 
+	// MARK: - Services (#149)
+
+	/// "New Jot Note from Selection": selected text in any app becomes an
+	/// untitled Jot draft. Declared in Info.plist under NSServices; the
+	/// selector name must match its NSMessage entry. MainActor is safe:
+	/// AppKit delivers service messages on the main thread.
+	@MainActor @objc func newJotNoteFromSelection(_ pboard: NSPasteboard,
+	                                   userData: String?,
+	                                   error: AutoreleasingUnsafeMutablePointer<NSString?>) {
+		guard let text = pboard.string(forType: .string), !text.isEmpty else {
+			error.pointee = "No text was found in the selection." as NSString
+			return
+		}
+		Document.makeUntitledDocument(withText: text)
+	}
+
 	private func openInFinderCreatingIfNeeded(_ folder: URL?) {
 		guard let folder else { return }
 		do {
@@ -193,6 +209,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
 			openFolderTarget: self)
 		snippetMenuSource = snippetSource
 		insertSnippetMenu?.delegate = snippetSource
+
+		// Receiver for the NSServices entry in Info.plist (#149)
+		NSApp.servicesProvider = self
 	}
 
 	func applicationSupportsSecureRestorableState(_ app: NSApplication) -> Bool {

--- a/Jot/App/Document.swift
+++ b/Jot/App/Document.swift
@@ -422,7 +422,26 @@ class Document: NSDocument {
 		return newDocument
 	}
 
-	// MARK: - New from Template (#161)
+	// MARK: - Untitled drafts with content (#161, #149)
+
+	/// Untitled draft pre-filled with `text` — the shared core of New
+	/// from Template (#161) and the New Jot Note from Selection service
+	/// (#149).
+	@discardableResult
+	static func makeUntitledDocument(withText text: String, fileType: String? = nil) -> Document {
+		let doc = Document()
+		doc.text = LineEnding.normalizeToLF(text)
+		if let fileType {
+			doc.fileType = fileType
+		}
+		// Mark edited so the draft participates in NSDocument autosave
+		// and closing the window prompts to save (#120)
+		doc.updateChangeCount(.changeDone)
+		NSDocumentController.shared.addDocument(doc)
+		doc.makeWindowControllers()
+		doc.showWindows()
+		return doc
+	}
 
 	/// Untitled draft seeded from a template file. Untitled on purpose:
 	/// the template is stationery — the new document must never point
@@ -433,21 +452,13 @@ class Document: NSDocument {
 		// contract; a non-UTF-8 file surfaces as a read error.
 		let raw = try String(contentsOf: url, encoding: .utf8)
 
-		let doc = Document()
-		doc.text = LineEnding.normalizeToLF(raw)
 		// fileType rather than modeOverride: the override is the user's
 		// explicit choice and is persisted to the view-settings xattr on
 		// save (#157). The type only steers initialEditorMode's inference.
-		if EditorMode.inferred(fromTypeIdentifier: nil, filenameExtension: url.pathExtension) == .markdown {
-			doc.fileType = "net.daringfireball.markdown"
-		}
-		// Mark edited so the draft participates in NSDocument autosave
-		// and closing the window prompts to save (#120)
-		doc.updateChangeCount(.changeDone)
-		NSDocumentController.shared.addDocument(doc)
-		doc.makeWindowControllers()
-		doc.showWindows()
-		return doc
+		let isMarkdown = EditorMode.inferred(fromTypeIdentifier: nil,
+											filenameExtension: url.pathExtension) == .markdown
+		return makeUntitledDocument(withText: raw,
+									fileType: isMarkdown ? "net.daringfireball.markdown" : nil)
 	}
 
 	// MARK: - Legacy unsaved-state migration

--- a/Jot/Resources/Info.plist
+++ b/Jot/Resources/Info.plist
@@ -111,6 +111,22 @@
 			</dict>
 		</dict>
 	</array>
+	<key>NSServices</key>
+	<array>
+		<dict>
+			<key>NSMenuItem</key>
+			<dict>
+				<key>default</key>
+				<string>New Jot Note from Selection</string>
+			</dict>
+			<key>NSMessage</key>
+			<string>newJotNoteFromSelection</string>
+			<key>NSSendTypes</key>
+			<array>
+				<string>NSStringPboardType</string>
+			</array>
+		</dict>
+	</array>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 </dict>

--- a/JotTests/DocumentTests.swift
+++ b/JotTests/DocumentTests.swift
@@ -356,6 +356,20 @@ final class DocumentTests: XCTestCase {
         try body(tempFolder)
     }
 
+    func testMakeUntitledDocumentWithTextCreatesEditedDraft() throws {
+        let marker = "text-\(UUID().uuidString)\r\nsecond"
+
+        let doc = Document.makeUntitledDocument(withText: marker)
+        defer { doc.close() }
+
+        XCTAssertTrue(NSDocumentController.shared.documents.contains(doc))
+        XCTAssertTrue(doc.text.hasPrefix("text-"), "text should be seeded")
+        XCTAssertTrue(doc.text.hasSuffix("\nsecond"), "CRLF must be LF-normalized")
+        XCTAssertTrue(doc.isDocumentEdited)
+        XCTAssertNil(doc.fileURL)
+        XCTAssertEqual(doc.initialEditorMode, .plainText)
+    }
+
     func testTemplateCreatesEditedUntitledDocument() throws {
         try withTemplateFolder { folder in
             let marker = "template-\(UUID().uuidString)"

--- a/JotTests/ServiceProviderTests.swift
+++ b/JotTests/ServiceProviderTests.swift
@@ -1,0 +1,59 @@
+//
+//  ServiceProviderTests.swift
+//  JotTests
+//
+//  Tests for the "New Jot Note from Selection" service handler (#149).
+//  The NSServices registration itself is Info.plist configuration and
+//  is covered by the manual checklist, not unit tests.
+//
+
+import XCTest
+@testable import Jot
+
+@MainActor
+final class ServiceProviderTests: XCTestCase {
+
+    /// A unique pasteboard so tests never touch the general pasteboard.
+    private func withPasteboard(_ body: (NSPasteboard) throws -> Void) rethrows {
+        let pboard = NSPasteboard(name: NSPasteboard.Name("JotTests-\(UUID().uuidString)"))
+        defer { pboard.releaseGlobally() }
+        try body(pboard)
+    }
+
+    private func appDelegate() throws -> AppDelegate {
+        try XCTUnwrap(NSApp.delegate as? AppDelegate)
+    }
+
+    func testServiceCreatesDocumentFromPasteboardText() throws {
+        try withPasteboard { pboard in
+            let marker = "service-\(UUID().uuidString)"
+            pboard.clearContents()
+            pboard.setString(marker, forType: .string)
+            var serviceError: NSString?
+
+            try appDelegate().newJotNoteFromSelection(pboard, userData: nil, error: &serviceError)
+
+            let created = NSDocumentController.shared.documents
+                .compactMap { $0 as? Document }
+                .first { $0.text == marker }
+            defer { created?.close() }
+
+            XCTAssertNil(serviceError)
+            XCTAssertNotNil(created, "the service should open a draft holding the selection")
+            XCTAssertEqual(created?.isDocumentEdited, true)
+        }
+    }
+
+    func testServiceWithoutTextReportsErrorAndAddsNoDocument() throws {
+        try withPasteboard { pboard in
+            pboard.clearContents()
+            var serviceError: NSString?
+            let countBefore = NSDocumentController.shared.documents.count
+
+            try appDelegate().newJotNoteFromSelection(pboard, userData: nil, error: &serviceError)
+
+            XCTAssertNotNil(serviceError)
+            XCTAssertEqual(NSDocumentController.shared.documents.count, countBefore)
+        }
+    }
+}


### PR DESCRIPTION
Closes #149. Third feature of the Content and Capture milestone.

**Stacked on #162's branch** — this PR's base is `feat/162-insert-snippet` so the diff shows only the Services work. After #162 merges, retarget to `develop` (GitHub usually does this automatically when the base branch is deleted on merge).

## What this adds

- **NSServices entry in Info.plist**: "New Jot Note from Selection" appears in every app's Services menu when text is selected, and System Settings > Keyboard Shortcuts > Services lets the user assign it a system-wide shortcut. Genuinely old-school Mac, as the issue intended.
- **Service handler on AppDelegate** (`newJotNoteFromSelection`), registered via `NSApp.servicesProvider` at launch: reads the string off the pasteboard and opens an untitled, edited draft holding it. Empty/no text reports a service error instead of opening an empty window.
- Receiving text requires no entitlements and works within the existing sandbox.

## Design notes

- The create-with-content core is extracted from the #161 template factory into `Document.makeUntitledDocument(withText:fileType:)`; templates and the service now share one path (CRLF→LF normalization, edited-draft semantics per #120, untitled naming).
- The handler is `@MainActor` — AppKit delivers service messages on the main thread, and the compiler requires the isolation for the `Document` calls.

## Testing

- New `ServiceProviderTests` (2): a unique named pasteboard drives the handler directly — draft created with the pasteboard text and marked edited; empty pasteboard reports an error and adds no document. Plus a `DocumentTests` case for the extracted factory.
- Full suite green locally.
- Manual: after first launch the service appears under Services (macOS caches the menu — `pbs -update` or a re-login may be needed once); invoking it from another app launches Jot and opens the draft.

Generated with [Claude Code](https://claude.com/claude-code)
