### PR TITLE
chore: #239 hardening batch (items 3-6) + service activation follow-up

### DIFF
--- a/Jot/App/AppDelegate.swift
+++ b/Jot/App/AppDelegate.swift
@@ -158,14 +158,13 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
 			serviceCreatedDraftDuringLaunch = true
 		}
 		Document.makeUntitledDocument(withText: text)
-		// The services system does not activate the provider app; without
-		// this the draft opens behind the app the user invoked us from.
-		// The deprecated call is deliberate: macOS 14's cooperative
-		// NSApp.activate() is a request the system denies while the app
-		// the user invoked us from is frontmost — exactly this situation.
-		// The sanctioned handoff (yieldActivation) must be called by the
-		// source app, which we do not control. Deprecated-but-forcing is
-		// the only working option (same conclusion as MacVim #1456).
+		// The services system does not activate the provider app. Known
+		// broken on Sequoia: neither the cooperative NSApp.activate()
+		// (a request, denied while the source app is frontmost) nor this
+		// deprecated forcing call brings the draft forward — tested
+		// empirically 2026-08. Kept because it is harmless, correct on
+		// older systems, and the best sanctioned attempt; the
+		// investigation of stronger options lives in #243.
 		NSApp.activate(ignoringOtherApps: true)
 	}
 

--- a/Jot/App/AppDelegate.swift
+++ b/Jot/App/AppDelegate.swift
@@ -160,11 +160,13 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
 		Document.makeUntitledDocument(withText: text)
 		// The services system does not activate the provider app; without
 		// this the draft opens behind the app the user invoked us from.
-		if #available(macOS 14.0, *) {
-			NSApp.activate()
-		} else {
-			NSApp.activate(ignoringOtherApps: true)
-		}
+		// The deprecated call is deliberate: macOS 14's cooperative
+		// NSApp.activate() is a request the system denies while the app
+		// the user invoked us from is frontmost — exactly this situation.
+		// The sanctioned handoff (yieldActivation) must be called by the
+		// source app, which we do not control. Deprecated-but-forcing is
+		// the only working option (same conclusion as MacVim #1456).
+		NSApp.activate(ignoringOtherApps: true)
 	}
 
 	func applicationShouldOpenUntitledFile(_ sender: NSApplication) -> Bool {

--- a/Jot/App/AppDelegate.swift
+++ b/Jot/App/AppDelegate.swift
@@ -147,6 +147,13 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
 			error.pointee = "No text was found in the selection." as NSString
 			return
 		}
+		// A pasteboard has no pre-read size query, so the string is
+		// already in memory — but the expensive part (normalize, style,
+		// layout) has not run yet, and that is what the guard prevents.
+		guard text.utf8.count <= Document.maximumInputBytes else {
+			error.pointee = "The selection is too large for a Jot note." as NSString
+			return
+		}
 		if !hasFinishedLaunching {
 			serviceCreatedDraftDuringLaunch = true
 		}

--- a/Jot/App/Document.swift
+++ b/Jot/App/Document.swift
@@ -104,6 +104,9 @@ class Document: NSDocument {
 	}
 
 	override func read(from url: URL, ofType typeName: String) throws {
+		// Refuse before the default implementation materializes the whole
+		// file as Data — the guard is pointless after the bytes load.
+		try Self.checkInputSize(ofFileAt: url)
 		// Peek at the com.apple.TextEncoding attribute before the default
 		// implementation funnels down to read(from:ofType:) with bare data
 		xattrEncodingHint = Self.encodingFromExtendedAttribute(at: url)
@@ -422,6 +425,42 @@ class Document: NSDocument {
 		return newDocument
 	}
 
+	// MARK: - Input size guard (#239)
+
+	/// Upper bound for every text input path: opening a file, reading a
+	/// template or snippet, the service pasteboard. Every read is
+	/// synchronous on the main thread and the buffer is copied several
+	/// times on the way in (decode, normalize, style), so unbounded
+	/// input beachballs the app. 32 MB of plain text is far beyond any
+	/// note; the guard exists for the accidental 500 MB log file.
+	static let maximumInputBytes = 32 * 1024 * 1024
+
+	/// fileReadTooLarge so NSDocument presents it like any other read
+	/// failure.
+	static func inputTooLargeError(filename: String) -> NSError {
+		let limitMB = maximumInputBytes / (1024 * 1024)
+		return NSError(domain: NSCocoaErrorDomain,
+					   code: NSFileReadTooLargeError,
+					   userInfo: [NSLocalizedDescriptionKey:
+						"\u{201C}\(filename)\u{201D} is too large to open in Jot. The limit is \(limitMB) MB of text."])
+	}
+
+	/// Throws before any bytes load if the file exceeds the guard.
+	static func checkInputSize(ofFileAt url: URL) throws {
+		let size = (try? url.resourceValues(forKeys: [.fileSizeKey]))?.fileSize ?? 0
+		if size > maximumInputBytes {
+			throw inputTooLargeError(filename: url.lastPathComponent)
+		}
+	}
+
+	/// The template and snippet read, in one place so both stay behind
+	/// the size guard. UTF-8 is the contract for both: they are files
+	/// the user authors in Jot (#161, #162).
+	static func boundedUTF8Read(from url: URL) throws -> String {
+		try checkInputSize(ofFileAt: url)
+		return try String(contentsOf: url, encoding: .utf8)
+	}
+
 	// MARK: - Untitled drafts with content (#161, #149)
 
 	/// Untitled draft pre-filled with `text` — the shared core of New
@@ -448,9 +487,7 @@ class Document: NSDocument {
 	/// back at it.
 	@discardableResult
 	static func makeUntitledDocument(fromTemplateAt url: URL) throws -> Document {
-		// Templates are files the user authors in Jot, so UTF-8 is the
-		// contract; a non-UTF-8 file surfaces as a read error.
-		let raw = try String(contentsOf: url, encoding: .utf8)
+		let raw = try boundedUTF8Read(from: url)
 
 		// fileType rather than modeOverride: the override is the user's
 		// explicit choice and is persisted to the view-settings xattr on

--- a/Jot/Editor/EditorViewController.swift
+++ b/Jot/Editor/EditorViewController.swift
@@ -607,11 +607,9 @@ class EditorViewController: NSViewController, NSTextViewDelegate {
 	/// is key (see the #125 note in AppDelegate).
 	@IBAction func insertSnippet(_ sender: Any?) {
 		guard let url = (sender as? NSMenuItem)?.representedObject as? URL else { return }
-		// Snippets are files the user authors in Jot, so UTF-8 is the
-		// contract — same as templates (#161)
 		let raw: String
 		do {
-			raw = try String(contentsOf: url, encoding: .utf8)
+			raw = try Document.boundedUTF8Read(from: url)
 		} catch {
 			NSApp.presentError(error)
 			return

--- a/Jot/Models/FolderMenuSource.swift
+++ b/Jot/Models/FolderMenuSource.swift
@@ -94,8 +94,16 @@ final class FolderMenuSource: NSObject, NSMenuDelegate {
 			// nil action leaves the item disabled via autoenablesItems.
 			menu.addItem(NSMenuItem(title: emptyTitle, action: nil, keyEquivalent: ""))
 		}
+
+		let basenames = files.map { $0.deletingPathExtension().lastPathComponent }
+		let collisions = Set(basenames.filter { name in
+			basenames.filter { $0 == name }.count > 1
+		})
+
 		for url in files {
-			let item = NSMenuItem(title: url.deletingPathExtension().lastPathComponent,
+			let basename = url.deletingPathExtension().lastPathComponent
+			let title = collisions.contains(basename) ? url.lastPathComponent : basename
+			let item = NSMenuItem(title: title,
 			                      action: selectionAction,
 			                      keyEquivalent: "")
 			item.target = selectionTarget
@@ -109,13 +117,10 @@ final class FolderMenuSource: NSObject, NSMenuDelegate {
 		menu.addItem(open)
 	}
 
-	/// No dynamic item ever has a key equivalent. Without this, AppKit
-	/// falls back to menuNeedsUpdate — a folder scan — on every Cmd-key
-	/// press during key-equivalent resolution.
-	func menuHasKeyEquivalent(_ menu: NSMenu,
-	                          for event: NSEvent,
-	                          target: AutoreleasingUnsafeMutablePointer<AnyObject?>,
-	                          action: UnsafeMutablePointer<Selector?>) -> Bool {
-		return false
-	}
+	// Deliberately no menuHasKeyEquivalent override: AppKit then
+	// populates the menu (a folder scan) during Cmd-key resolution,
+	// which is what lets user-assigned App Shortcuts reach every item
+	// here, including the dynamic ones. The scan is cheap — measured
+	// 2026-08-18 at ~0.4 ms warm for 25 files, ~2.5 ms for 100 — so
+	// blocking shortcuts to save it is a bad trade (#239).
 }

--- a/Jot/Resources/Info.plist
+++ b/Jot/Resources/Info.plist
@@ -123,7 +123,7 @@
 			<string>newJotNoteFromSelection</string>
 			<key>NSSendTypes</key>
 			<array>
-				<string>NSStringPboardType</string>
+				<string>public.utf8-plain-text</string>
 			</array>
 		</dict>
 	</array>

--- a/JotTests/DocumentTests.swift
+++ b/JotTests/DocumentTests.swift
@@ -427,6 +427,58 @@ final class DocumentTests: XCTestCase {
         }
     }
 
+    // MARK: - Input size guard (#239)
+
+    /// One byte past the limit — the guard checks size before any bytes
+    /// load, so the writes here are the only expensive part.
+    private func writeOversizedFile(named name: String, in folder: URL) throws -> URL {
+        let url = folder.appendingPathComponent(name)
+        let oversized = Data(repeating: UInt8(ascii: "a"), count: Document.maximumInputBytes + 1)
+        try oversized.write(to: url)
+        return url
+    }
+
+    func testBoundedReadAcceptsSmallFile() throws {
+        try withTemplateFolder { folder in
+            let url = folder.appendingPathComponent("Small.txt")
+            try "hello".write(to: url, atomically: true, encoding: .utf8)
+
+            XCTAssertEqual(try Document.boundedUTF8Read(from: url), "hello")
+        }
+    }
+
+    func testBoundedReadRejectsOversizedFile() throws {
+        try withTemplateFolder { folder in
+            let url = try writeOversizedFile(named: "Huge.txt", in: folder)
+
+            XCTAssertThrowsError(try Document.boundedUTF8Read(from: url)) { error in
+                XCTAssertEqual((error as NSError).code, NSFileReadTooLargeError)
+            }
+        }
+    }
+
+    func testOpenRejectsOversizedFile() throws {
+        try withTemplateFolder { folder in
+            let url = try writeOversizedFile(named: "Huge.txt", in: folder)
+            let doc = Document()
+
+            XCTAssertThrowsError(try doc.read(from: url, ofType: "public.plain-text")) { error in
+                XCTAssertEqual((error as NSError).code, NSFileReadTooLargeError)
+            }
+            XCTAssertEqual(doc.text, "", "no partial content on a refused read")
+        }
+    }
+
+    func testOversizedTemplateThrowsAndAddsNoDocument() throws {
+        try withTemplateFolder { folder in
+            let url = try writeOversizedFile(named: "Huge.md", in: folder)
+            let countBefore = NSDocumentController.shared.documents.count
+
+            XCTAssertThrowsError(try Document.makeUntitledDocument(fromTemplateAt: url))
+            XCTAssertEqual(NSDocumentController.shared.documents.count, countBefore)
+        }
+    }
+
     // MARK: - Legacy unsaved-state migration (#121)
 
     func testMigrationRestoresLegacyDraftAsEditedDocument() throws {

--- a/JotTests/FolderMenuSourceTests.swift
+++ b/JotTests/FolderMenuSourceTests.swift
@@ -184,6 +184,24 @@ final class FolderMenuSourceTests: XCTestCase {
         }
     }
 
+    /// "Notes.txt" and "Notes.md" as bare "Notes" twice are identical
+    /// visually and to VoiceOver — and behave differently, since the
+    /// extension steers the template's mode (#239).
+    func testMenuShowsExtensionsForCollidingBasenames() throws {
+        try withTempFolder { folder in
+            try createFile("Notes.txt", in: folder)
+            try createFile("Notes.md", in: folder)
+            try createFile("Agenda.md", in: folder)
+            let source = makeSource(folder: folder)
+            let menu = NSMenu()
+
+            source.menuNeedsUpdate(menu)
+
+            XCTAssertEqual(menu.items.prefix(3).map(\.title),
+                           ["Agenda", "Notes.md", "Notes.txt"])
+        }
+    }
+
     func testNilSelectionTargetYieldsNilItemTargets() throws {
         try withTempFolder { folder in
             try createFile("Notes.txt", in: folder)

--- a/JotTests/ServiceProviderTests.swift
+++ b/JotTests/ServiceProviderTests.swift
@@ -64,6 +64,22 @@ final class ServiceProviderTests: XCTestCase {
         }
     }
 
+    func testServiceRejectsOversizedSelection() throws {
+        try withPasteboard { pboard in
+            pboard.clearContents()
+            // One byte past the guard; ASCII so bytes == characters
+            pboard.setString(String(repeating: "a", count: Document.maximumInputBytes + 1),
+                             forType: .string)
+            var serviceError: NSString?
+            let countBefore = NSDocumentController.shared.documents.count
+
+            try appDelegate().newJotNoteFromSelection(pboard, userData: nil, error: &serviceError)
+
+            XCTAssertNotNil(serviceError)
+            XCTAssertEqual(NSDocumentController.shared.documents.count, countBefore)
+        }
+    }
+
     func testServiceWithoutTextReportsErrorAndAddsNoDocument() throws {
         try withPasteboard { pboard in
             pboard.clearContents()


### PR DESCRIPTION
## Summary

Closes out the #239 hardening batch (items 3-6) and follows up on the service-activation work from #242.

### #239 items 3-6

- **App Shortcuts (item 3):** deleted `FolderMenuSource.menuHasKeyEquivalent` instead of carving out titles. The folder scan it guarded against was measured at ~0.06 ms for 5 files, ~0.4 ms for 25, ~2.5 ms for 100 (warm cache) — imperceptible at any realistic size, and the guard blocked user-assigned App Shortcuts for every item in both dynamic submenus. A comment at the former site records the measurement so the guard does not quietly return.
- **Colliding basenames (item 4):** `Notes.txt` and `Notes.md` no longer render as two identical "Notes" items — the extension is shown for colliding basenames only.
- **Pasteboard type (item 5):** `NSSendTypes` modernized from `NSStringPboardType` to `public.utf8-plain-text`.
- **Input size guard (item 6):** one shared `Document.maximumInputBytes` (32 MB) now bounds every text input path — ordinary Open (checked before the file materializes as Data), templates and snippets (shared `boundedUTF8Read`), and the service pasteboard (checked before normalize/style work). File-path refusals throw `NSFileReadTooLargeError` so NSDocument presents them normally. **User-visible change:** files over 32 MB now get an error dialog instead of beachballing the app.

### Service activation follow-up (#243)

The cooperative `NSApp.activate()` from #242 is a request the system denies while the source app is frontmost — every warm service invocation. Replaced with the deprecated forcing call, which testing then showed also fails to foreground on Sequoia. The call stays (harmless, correct on older systems); the comment states the truth and the investigation lives in #243, filed non-blocking.

## Testing

- 360 tests green locally (six new: bounded read accept/reject, oversized Open refusal, oversized template, oversized service selection, collision titles), zero warnings.
- Manually verified by Brian: cold-launch service opens exactly one window; warm-service foregrounding confirmed broken and tracked in #243.

Refs #239, #243

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H9Asj7Vqhs5hoB1nVs6Se4
