### PR TITLE
feat: Create New Template/Snippet with name-first dialog and folder badges (#233, #238)

### DIFF
--- a/Jot/App/AppDelegate.swift
+++ b/Jot/App/AppDelegate.swift
@@ -120,12 +120,15 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
 		openInFinderCreatingIfNeeded(templateMenuSource?.folder)
 	}
 
-	/// Create New Template… (#233): an untitled draft whose first save
-	/// panel opens pointed at the Templates folder. MainActor like the
-	/// service handler: AppKit dispatches menu actions on the main
-	/// thread.
+	/// Create New Template… (#233): name-first dialog, then the file is
+	/// created directly in the Templates folder and opened saved-in-
+	/// place. No save panel anywhere in the flow — the powerbox refuses
+	/// to point one inside the sandbox container (by design, per Apple),
+	/// so steering NSSavePanel there is impossible, not just fragile.
+	/// MainActor like the service handler: AppKit dispatches menu
+	/// actions on the main thread.
 	@MainActor @IBAction func createNewTemplate(_ sender: Any?) {
-		makeAuthoringDocument(steeredTo: templateMenuSource?.folder, seed: "")
+		createAuthoringFile(kind: "Template", folder: templateMenuSource?.folder, seed: "")
 	}
 
 	// MARK: - Insert Snippet (#162)
@@ -142,24 +145,54 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
 	Replace this text with your snippet.
 	"""
 
-	/// Create New Snippet… (#238): same steering as templates, seeded
-	/// with the variable primer above.
+	/// Create New Snippet… (#238): same flow as templates, seeded with
+	/// the variable primer above.
 	@MainActor @IBAction func createNewSnippet(_ sender: Any?) {
-		makeAuthoringDocument(steeredTo: snippetMenuSource?.folder, seed: Self.snippetStarterText)
+		createAuthoringFile(kind: "Snippet", folder: snippetMenuSource?.folder, seed: Self.snippetStarterText)
 	}
 
-	/// The folder must exist before the save panel points at it — a
-	/// missing directoryURL makes NSSavePanel fall back to its default
-	/// location and the steering silently does nothing.
-	@MainActor private func makeAuthoringDocument(steeredTo folder: URL?, seed: String) {
+	@MainActor private func createAuthoringFile(kind: String, folder: URL?, seed: String) {
 		guard let folder else { return }
+
+		let alert = NSAlert()
+		alert.messageText = "New \(kind)"
+		alert.informativeText = "The file is saved in your \(kind)s folder. End the name with .md for Markdown; anything else is saved as plain text."
+		alert.addButton(withTitle: "Create")
+		alert.addButton(withTitle: "Cancel")
+		let nameField = NSTextField(frame: NSRect(x: 0, y: 0, width: 240, height: 24))
+		nameField.placeholderString = "\(kind) name"
+		alert.accessoryView = nameField
+		alert.window.initialFirstResponder = nameField
+
+		guard alert.runModal() == .alertFirstButtonReturn,
+		      let filename = FolderMenuSource.authoringFileName(from: nameField.stringValue) else {
+			return
+		}
+
 		do {
 			try FileManager.default.createDirectory(at: folder, withIntermediateDirectories: true)
+			// withoutOverwriting makes a name collision fail with the
+			// stock "already exists" error instead of destroying the
+			// existing template or snippet.
+			try Data(seed.utf8).write(to: folder.appendingPathComponent(filename),
+			                          options: [.withoutOverwriting])
 		} catch {
 			NSApp.presentError(error)
 			return
 		}
-		Document.makeAuthoringDocument(withText: seed, steeredTo: folder)
+
+		NSDocumentController.shared.openDocument(
+			withContentsOf: folder.appendingPathComponent(filename),
+			display: true
+		) { _, _, error in
+			if let error {
+				// AppKit calls this completion on the main thread, but the
+				// closure type is not MainActor-annotated — hop explicitly.
+				DispatchQueue.main.async {
+					NSApp.presentError(error)
+				}
+			}
+		}
 	}
 
 	// MARK: - Services (#149)

--- a/Jot/App/AppDelegate.swift
+++ b/Jot/App/AppDelegate.swift
@@ -114,16 +114,52 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
 		}
 	}
 
-	/// The Templates and Snippets folders are only ever created here,
-	/// never during a menu scan.
+	/// The Templates and Snippets folders are only ever created by the
+	/// open-folder and create-new actions, never during a menu scan.
 	@IBAction func openTemplatesFolder(_ sender: Any?) {
 		openInFinderCreatingIfNeeded(templateMenuSource?.folder)
+	}
+
+	/// Create New Template… (#233): an untitled draft whose first save
+	/// panel opens pointed at the Templates folder. MainActor like the
+	/// service handler: AppKit dispatches menu actions on the main
+	/// thread.
+	@MainActor @IBAction func createNewTemplate(_ sender: Any?) {
+		makeAuthoringDocument(steeredTo: templateMenuSource?.folder, seed: "")
 	}
 
 	// MARK: - Insert Snippet (#162)
 
 	@IBAction func openSnippetsFolder(_ sender: Any?) {
 		openInFinderCreatingIfNeeded(snippetMenuSource?.folder)
+	}
+
+	/// Starter text for Create New Snippet… (#238) — the variables are
+	/// documented nowhere else in the app, so the seed is the
+	/// discoverability. The author deletes it.
+	static let snippetStarterText = """
+	Snippets can use {{date}}, {{time}}, and {{cursor}}.
+	Replace this text with your snippet.
+	"""
+
+	/// Create New Snippet… (#238): same steering as templates, seeded
+	/// with the variable primer above.
+	@MainActor @IBAction func createNewSnippet(_ sender: Any?) {
+		makeAuthoringDocument(steeredTo: snippetMenuSource?.folder, seed: Self.snippetStarterText)
+	}
+
+	/// The folder must exist before the save panel points at it — a
+	/// missing directoryURL makes NSSavePanel fall back to its default
+	/// location and the steering silently does nothing.
+	@MainActor private func makeAuthoringDocument(steeredTo folder: URL?, seed: String) {
+		guard let folder else { return }
+		do {
+			try FileManager.default.createDirectory(at: folder, withIntermediateDirectories: true)
+		} catch {
+			NSApp.presentError(error)
+			return
+		}
+		Document.makeAuthoringDocument(withText: seed, steeredTo: folder)
 	}
 
 	// MARK: - Services (#149)
@@ -231,9 +267,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
 			emptyTitle: "No Templates",
 			selectionAction: #selector(newDocumentFromTemplate(_:)),
 			selectionTarget: self,
-			openFolderTitle: "Open Templates Folder",
-			openFolderAction: #selector(openTemplatesFolder(_:)),
-			openFolderTarget: self)
+			trailingItems: [
+				.init(title: "Create New Template…", action: #selector(createNewTemplate(_:))),
+				.init(title: "Open Templates Folder", action: #selector(openTemplatesFolder(_:))),
+			],
+			trailingTarget: self)
 		templateMenuSource = source
 		newFromTemplateMenu?.delegate = source
 
@@ -246,9 +284,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
 			emptyTitle: "No Snippets",
 			selectionAction: #selector(EditorViewController.insertSnippet(_:)),
 			selectionTarget: nil,
-			openFolderTitle: "Open Snippets Folder",
-			openFolderAction: #selector(openSnippetsFolder(_:)),
-			openFolderTarget: self)
+			trailingItems: [
+				.init(title: "Create New Snippet…", action: #selector(createNewSnippet(_:))),
+				.init(title: "Open Snippets Folder", action: #selector(openSnippetsFolder(_:))),
+			],
+			trailingTarget: self)
 		snippetMenuSource = snippetSource
 		insertSnippetMenu?.delegate = snippetSource
 

--- a/Jot/App/Document.swift
+++ b/Jot/App/Document.swift
@@ -8,7 +8,6 @@
 import Cocoa
 import os
 import os.signpost
-import UniformTypeIdentifiers
 
 class Document: NSDocument {
 	private static let log = Logger(subsystem: "com.brian.jot", category: "document")
@@ -465,47 +464,6 @@ class Document: NSDocument {
 	static func boundedUTF8Read(from url: URL) throws -> String {
 		try checkInputSize(ofFileAt: url)
 		return try String(contentsOf: url, encoding: .utf8)
-	}
-
-	// MARK: - Template and snippet authoring (#233, #238)
-
-	/// When set, the first save panel opens pointed at this folder —
-	/// the steering behind Create New Template / Create New Snippet.
-	/// A default, not a constraint: the user can navigate away and the
-	/// save degrades to a plain save anywhere. Transient, never
-	/// persisted.
-	var savePanelDirectory: URL?
-
-	override func prepareSavePanel(_ savePanel: NSSavePanel) -> Bool {
-		// Only until the first save: once the file exists, Save As
-		// should default next to it like any other document.
-		if fileURL == nil, let savePanelDirectory {
-			savePanel.directoryURL = savePanelDirectory
-			// The submenus only list .txt and .md (#161, #162); steer
-			// the extension too so the saved file actually appears there.
-			savePanel.allowedContentTypes = [.plainText, UTType("net.daringfireball.markdown")]
-				.compactMap { $0 }
-		}
-		return true
-	}
-
-	/// Untitled draft whose first save is steered to `folder` — the
-	/// shared core of Create New Template (#233) and Create New Snippet
-	/// (#238). Unlike makeUntitledDocument, an empty draft is not
-	/// marked edited: closing an untouched Create New Template window
-	/// should not prompt to save nothing.
-	@discardableResult
-	static func makeAuthoringDocument(withText text: String, steeredTo folder: URL) -> Document {
-		let doc = Document()
-		doc.text = LineEnding.normalizeToLF(text)
-		doc.savePanelDirectory = folder
-		if !text.isEmpty {
-			doc.updateChangeCount(.changeDone)
-		}
-		NSDocumentController.shared.addDocument(doc)
-		doc.makeWindowControllers()
-		doc.showWindows()
-		return doc
 	}
 
 	// MARK: - Untitled drafts with content (#161, #149)

--- a/Jot/App/Document.swift
+++ b/Jot/App/Document.swift
@@ -8,6 +8,7 @@
 import Cocoa
 import os
 import os.signpost
+import UniformTypeIdentifiers
 
 class Document: NSDocument {
 	private static let log = Logger(subsystem: "com.brian.jot", category: "document")
@@ -433,11 +434,14 @@ class Document: NSDocument {
 	/// times on the way in (decode, normalize, style), so unbounded
 	/// input beachballs the app. 32 MB of plain text is far beyond any
 	/// note; the guard exists for the accidental 500 MB log file.
-	static let maximumInputBytes = 32 * 1024 * 1024
+	/// nonisolated (with the two members below): pure values and
+	/// FileManager metadata, callable from the nonisolated
+	/// read(from:ofType:) override.
+	nonisolated static let maximumInputBytes = 32 * 1024 * 1024
 
 	/// fileReadTooLarge so NSDocument presents it like any other read
 	/// failure.
-	static func inputTooLargeError(filename: String) -> NSError {
+	nonisolated static func inputTooLargeError(filename: String) -> NSError {
 		let limitMB = maximumInputBytes / (1024 * 1024)
 		return NSError(domain: NSCocoaErrorDomain,
 					   code: NSFileReadTooLargeError,
@@ -446,7 +450,9 @@ class Document: NSDocument {
 	}
 
 	/// Throws before any bytes load if the file exceeds the guard.
-	static func checkInputSize(ofFileAt url: URL) throws {
+	/// nonisolated: pure file-system metadata work, and the caller
+	/// read(from:ofType:) inherits nonisolated from NSDocument.
+	nonisolated static func checkInputSize(ofFileAt url: URL) throws {
 		let size = (try? url.resourceValues(forKeys: [.fileSizeKey]))?.fileSize ?? 0
 		if size > maximumInputBytes {
 			throw inputTooLargeError(filename: url.lastPathComponent)
@@ -459,6 +465,47 @@ class Document: NSDocument {
 	static func boundedUTF8Read(from url: URL) throws -> String {
 		try checkInputSize(ofFileAt: url)
 		return try String(contentsOf: url, encoding: .utf8)
+	}
+
+	// MARK: - Template and snippet authoring (#233, #238)
+
+	/// When set, the first save panel opens pointed at this folder —
+	/// the steering behind Create New Template / Create New Snippet.
+	/// A default, not a constraint: the user can navigate away and the
+	/// save degrades to a plain save anywhere. Transient, never
+	/// persisted.
+	var savePanelDirectory: URL?
+
+	override func prepareSavePanel(_ savePanel: NSSavePanel) -> Bool {
+		// Only until the first save: once the file exists, Save As
+		// should default next to it like any other document.
+		if fileURL == nil, let savePanelDirectory {
+			savePanel.directoryURL = savePanelDirectory
+			// The submenus only list .txt and .md (#161, #162); steer
+			// the extension too so the saved file actually appears there.
+			savePanel.allowedContentTypes = [.plainText, UTType("net.daringfireball.markdown")]
+				.compactMap { $0 }
+		}
+		return true
+	}
+
+	/// Untitled draft whose first save is steered to `folder` — the
+	/// shared core of Create New Template (#233) and Create New Snippet
+	/// (#238). Unlike makeUntitledDocument, an empty draft is not
+	/// marked edited: closing an untouched Create New Template window
+	/// should not prompt to save nothing.
+	@discardableResult
+	static func makeAuthoringDocument(withText text: String, steeredTo folder: URL) -> Document {
+		let doc = Document()
+		doc.text = LineEnding.normalizeToLF(text)
+		doc.savePanelDirectory = folder
+		if !text.isEmpty {
+			doc.updateChangeCount(.changeDone)
+		}
+		NSDocumentController.shared.addDocument(doc)
+		doc.makeWindowControllers()
+		doc.showWindows()
+		return doc
 	}
 
 	// MARK: - Untitled drafts with content (#161, #149)

--- a/Jot/Editor/EditorViewController.swift
+++ b/Jot/Editor/EditorViewController.swift
@@ -55,6 +55,23 @@ class EditorViewController: NSViewController, NSTextViewDelegate {
 		label.setAccessibilityLabel("File encoding and line endings")
 		return label
 	}()
+
+	/// "TEMPLATE" / "SNIPPET" when the file lives in the corresponding
+	/// Application Support folder (#233, #238) — tells editing a master
+	/// apart from editing an untitled copy. Empty (zero width) for
+	/// ordinary documents.
+	private let folderBadgeLabel: NSTextField = {
+		let label = NSTextField(labelWithString: "")
+		label.font = .systemFont(ofSize: NSFont.smallSystemFontSize, weight: .medium)
+		label.textColor = .secondaryLabelColor
+		label.translatesAutoresizingMaskIntoConstraints = false
+		return label
+	}()
+
+	/// Re-badges on Save As, Duplicate, Rename, and moves — everything
+	/// that changes fileURL. Torn down in viewWillDisappear with the
+	/// other observers.
+	private var fileURLObservation: NSKeyValueObservation?
 	
 	override func viewDidLoad() {
 		super.viewDidLoad()
@@ -68,10 +85,16 @@ class EditorViewController: NSViewController, NSTextViewDelegate {
 
 		if let bar = modePopUpButton.superview {
 			bar.addSubview(fileInfoLabel)
+			bar.addSubview(folderBadgeLabel)
 			NSLayoutConstraint.activate([
 				fileInfoLabel.trailingAnchor.constraint(equalTo: modePopUpButton.leadingAnchor, constant: -8),
 				fileInfoLabel.centerYAnchor.constraint(equalTo: modePopUpButton.centerYAnchor),
-				fileInfoLabel.leadingAnchor.constraint(greaterThanOrEqualTo: wordCountLabel.trailingAnchor, constant: 8),
+				// The badge sits left of the encoding indicator; empty
+				// string means zero width, so ordinary documents just
+				// carry a slightly wider gap there.
+				folderBadgeLabel.trailingAnchor.constraint(equalTo: fileInfoLabel.leadingAnchor, constant: -8),
+				folderBadgeLabel.centerYAnchor.constraint(equalTo: modePopUpButton.centerYAnchor),
+				folderBadgeLabel.leadingAnchor.constraint(greaterThanOrEqualTo: wordCountLabel.trailingAnchor, constant: 8),
 			])
 		}
 
@@ -119,14 +142,24 @@ class EditorViewController: NSViewController, NSTextViewDelegate {
 		updateGutterVisibility()
 		// The document association exists by now; loadText can run before it
 		updateFileInfoLabel()
+
+		// fileURL can change off the main thread (autosave machinery),
+		// hence the hop. Same appear/disappear lifecycle as the
+		// notification observers above.
+		fileURLObservation = (view.window?.windowController?.document as? Document)?
+			.observe(\.fileURL) { [weak self] _, _ in
+				DispatchQueue.main.async { self?.updateFileInfoLabel() }
+			}
 	}
 
-	/// Refreshes the encoding / line-ending indicator from the document
-	/// (#195). Called on appearance, after loads and reverts, and by the
-	/// document when a failed save was recovered by converting to UTF-8.
+	/// Refreshes the encoding / line-ending indicator and the folder
+	/// badge from the document (#195, #233). Called on appearance, after
+	/// loads and reverts, when fileURL changes, and by the document when
+	/// a failed save was recovered by converting to UTF-8.
 	func updateFileInfoLabel() {
 		guard let document = view.window?.windowController?.document as? Document else {
 			fileInfoLabel.stringValue = ""
+			folderBadgeLabel.stringValue = ""
 			return
 		}
 		fileInfoLabel.stringValue = "\(document.encodingDisplayName) · \(document.lineEnding.rawValue)"
@@ -135,6 +168,20 @@ class EditorViewController: NSViewController, NSTextViewDelegate {
 		// depending on punctuation verbosity — both worse than words
 		fileInfoLabel.setAccessibilityLabel(
 			"File encoding \(document.encodingDisplayName), \(document.lineEnding.rawValue) line endings")
+
+		let badge = FolderMenuSource.badgeLabel(for: document.fileURL)
+		folderBadgeLabel.stringValue = badge ?? ""
+		switch badge {
+		case "TEMPLATE":
+			folderBadgeLabel.setAccessibilityLabel("This file is in your Templates folder")
+			folderBadgeLabel.toolTip = "This file is a template: File > New from Template lists it."
+		case "SNIPPET":
+			folderBadgeLabel.setAccessibilityLabel("This file is in your Snippets folder")
+			folderBadgeLabel.toolTip = "This file is a snippet: Edit > Insert Snippet lists it."
+		default:
+			folderBadgeLabel.setAccessibilityLabel(nil)
+			folderBadgeLabel.toolTip = nil
+		}
 	}
 
 	@objc private func fontConfigurationDidChange(_ notification: Notification) {
@@ -169,6 +216,7 @@ class EditorViewController: NSViewController, NSTextViewDelegate {
 		wordCountUpdateTimer = nil
 		visibleRangeStyleTimer?.invalidate()
 		visibleRangeStyleTimer = nil
+		fileURLObservation = nil
 
 		// Same reason the timers stop here: a font change arriving between
 		// window close and dealloc would run a full styling pass over a text

--- a/Jot/Models/FolderMenuSource.swift
+++ b/Jot/Models/FolderMenuSource.swift
@@ -126,6 +126,27 @@ final class FolderMenuSource: NSObject, NSMenuDelegate {
 		}
 	}
 
+	// MARK: - Authoring file names (#233, #238)
+
+	/// Turns the name typed into the Create New Template/Snippet dialog
+	/// into a filename the submenu will actually list: a typed .txt or
+	/// .md extension is kept (it steers the mode, same as #161; these
+	/// are exactly the extensions both submenus scan for), anything
+	/// else gets .txt appended. Slashes and colons become dashes — the
+	/// two characters macOS filenames cannot carry. nil for a name that
+	/// is empty once trimmed.
+	nonisolated static func authoringFileName(from input: String) -> String? {
+		let trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines)
+			.replacingOccurrences(of: "/", with: "-")
+			.replacingOccurrences(of: ":", with: "-")
+		guard !trimmed.isEmpty else { return nil }
+		let listedExtensions: Set<String> = ["txt", "md"]
+		if listedExtensions.contains((trimmed as NSString).pathExtension.lowercased()) {
+			return trimmed
+		}
+		return trimmed + ".txt"
+	}
+
 	// MARK: - Folder badge (#233, #238)
 
 	/// "TEMPLATE" / "SNIPPET" when the file lives directly in the

--- a/Jot/Models/FolderMenuSource.swift
+++ b/Jot/Models/FolderMenuSource.swift
@@ -22,6 +22,14 @@ final class FolderMenuSource: NSObject, NSMenuDelegate {
 	/// the "Open … Folder" action, never during a menu scan.
 	var folder: URL?
 
+	/// A stable item below the separator — "Create New Template…",
+	/// "Open Templates Folder" (#233). These never depend on the folder
+	/// contents.
+	struct TrailingItem {
+		let title: String
+		let action: Selector
+	}
+
 	private let fileExtensions: Set<String>
 	private let emptyTitle: String
 	private let selectionAction: Selector
@@ -29,9 +37,8 @@ final class FolderMenuSource: NSObject, NSMenuDelegate {
 	/// auto-disables the items when nothing responds — Insert Snippet
 	/// (#162) uses this so its items dim when no editor is key.
 	private weak var selectionTarget: AnyObject?
-	private let openFolderTitle: String
-	private let openFolderAction: Selector
-	private weak var openFolderTarget: AnyObject?
+	private let trailingItems: [TrailingItem]
+	private weak var trailingTarget: AnyObject?
 
 	/// - Parameter fileExtensions: lowercase, without the dot.
 	init(folder: URL?,
@@ -39,22 +46,22 @@ final class FolderMenuSource: NSObject, NSMenuDelegate {
 	     emptyTitle: String,
 	     selectionAction: Selector,
 	     selectionTarget: AnyObject?,
-	     openFolderTitle: String,
-	     openFolderAction: Selector,
-	     openFolderTarget: AnyObject) {
+	     trailingItems: [TrailingItem],
+	     trailingTarget: AnyObject) {
 		self.folder = folder
 		self.fileExtensions = fileExtensions
 		self.emptyTitle = emptyTitle
 		self.selectionAction = selectionAction
 		self.selectionTarget = selectionTarget
-		self.openFolderTitle = openFolderTitle
-		self.openFolderAction = openFolderAction
-		self.openFolderTarget = openFolderTarget
+		self.trailingItems = trailingItems
+		self.trailingTarget = trailingTarget
 	}
 
 	/// App Support/Jot/<name> — the same container-relative resolution
-	/// as Document.unsavedStatesFolder.
-	static func applicationSupportFolder(named name: String) -> URL? {
+	/// as Document.unsavedStatesFolder. nonisolated: pure path
+	/// computation, and badgeLabel's default arguments (which evaluate
+	/// outside the actor) need to call it.
+	nonisolated static func applicationSupportFolder(named name: String) -> URL? {
 		guard let support = try? FileManager.default.url(for: .applicationSupportDirectory,
 		                                                 in: .userDomainMask,
 		                                                 appropriateFor: nil,
@@ -112,9 +119,34 @@ final class FolderMenuSource: NSObject, NSMenuDelegate {
 		}
 
 		menu.addItem(.separator())
-		let open = NSMenuItem(title: openFolderTitle, action: openFolderAction, keyEquivalent: "")
-		open.target = openFolderTarget
-		menu.addItem(open)
+		for trailing in trailingItems {
+			let item = NSMenuItem(title: trailing.title, action: trailing.action, keyEquivalent: "")
+			item.target = trailingTarget
+			menu.addItem(item)
+		}
+	}
+
+	// MARK: - Folder badge (#233, #238)
+
+	/// "TEMPLATE" / "SNIPPET" when the file lives directly in the
+	/// corresponding Application Support folder — the status-bar badge
+	/// that tells editing a template master apart from editing an
+	/// untitled copy made by New from Template. Folder parameters exist
+	/// for tests; production callers take the defaults. Worst case of a
+	/// comparison miss is a missing badge, never a wrong one.
+	nonisolated static func badgeLabel(for fileURL: URL?,
+	                                   templatesFolder: URL? = applicationSupportFolder(named: "Templates"),
+	                                   snippetsFolder: URL? = applicationSupportFolder(named: "Snippets")) -> String? {
+		guard let parent = fileURL?.deletingLastPathComponent().standardizedFileURL else {
+			return nil
+		}
+		if parent == templatesFolder?.standardizedFileURL {
+			return "TEMPLATE"
+		}
+		if parent == snippetsFolder?.standardizedFileURL {
+			return "SNIPPET"
+		}
+		return nil
 	}
 
 	// Deliberately no menuHasKeyEquivalent override: AppKit then

--- a/JotTests/DocumentTests.swift
+++ b/JotTests/DocumentTests.swift
@@ -427,6 +427,64 @@ final class DocumentTests: XCTestCase {
         }
     }
 
+    // MARK: - Template and snippet authoring (#233, #238)
+
+    func testAuthoringDocumentSteersFirstSavePanel() throws {
+        try withTemplateFolder { folder in
+            let doc = Document.makeAuthoringDocument(withText: "", steeredTo: folder)
+            defer { doc.close() }
+            let panel = NSSavePanel()
+
+            XCTAssertTrue(doc.prepareSavePanel(panel))
+
+            XCTAssertEqual(panel.directoryURL, folder)
+            XCTAssertFalse(panel.allowedContentTypes.isEmpty,
+                           "allowed types must pin the extension to what the submenu lists")
+        }
+    }
+
+    func testSavePanelNotSteeredOnceFileExists() throws {
+        try withTemplateFolder { folder in
+            let doc = Document.makeAuthoringDocument(withText: "", steeredTo: folder)
+            defer { doc.close() }
+            // Simulate the first save having happened
+            doc.fileURL = folder.appendingPathComponent("Saved.txt")
+            let panel = NSSavePanel()
+            let defaultDirectory = panel.directoryURL
+
+            XCTAssertTrue(doc.prepareSavePanel(panel))
+
+            XCTAssertEqual(panel.directoryURL, defaultDirectory,
+                           "Save As on a saved template should behave like any other document")
+        }
+    }
+
+    func testOrdinaryDocumentSavePanelUntouched() throws {
+        let doc = Document()
+        let panel = NSSavePanel()
+        let defaultDirectory = panel.directoryURL
+
+        XCTAssertTrue(doc.prepareSavePanel(panel))
+
+        XCTAssertEqual(panel.directoryURL, defaultDirectory)
+        XCTAssertTrue(panel.allowedContentTypes.isEmpty)
+    }
+
+    /// Closing an untouched Create New Template window must not prompt
+    /// to save nothing; a seeded snippet draft has real content and must.
+    func testAuthoringDocumentEditedOnlyWhenSeeded() throws {
+        try withTemplateFolder { folder in
+            let empty = Document.makeAuthoringDocument(withText: "", steeredTo: folder)
+            defer { empty.close() }
+            let seeded = Document.makeAuthoringDocument(withText: "starter", steeredTo: folder)
+            defer { seeded.close() }
+
+            XCTAssertFalse(empty.isDocumentEdited)
+            XCTAssertTrue(seeded.isDocumentEdited)
+            XCTAssertEqual(seeded.text, "starter")
+        }
+    }
+
     // MARK: - Input size guard (#239)
 
     /// One byte past the limit — the guard checks size before any bytes

--- a/JotTests/DocumentTests.swift
+++ b/JotTests/DocumentTests.swift
@@ -427,64 +427,6 @@ final class DocumentTests: XCTestCase {
         }
     }
 
-    // MARK: - Template and snippet authoring (#233, #238)
-
-    func testAuthoringDocumentSteersFirstSavePanel() throws {
-        try withTemplateFolder { folder in
-            let doc = Document.makeAuthoringDocument(withText: "", steeredTo: folder)
-            defer { doc.close() }
-            let panel = NSSavePanel()
-
-            XCTAssertTrue(doc.prepareSavePanel(panel))
-
-            XCTAssertEqual(panel.directoryURL, folder)
-            XCTAssertFalse(panel.allowedContentTypes.isEmpty,
-                           "allowed types must pin the extension to what the submenu lists")
-        }
-    }
-
-    func testSavePanelNotSteeredOnceFileExists() throws {
-        try withTemplateFolder { folder in
-            let doc = Document.makeAuthoringDocument(withText: "", steeredTo: folder)
-            defer { doc.close() }
-            // Simulate the first save having happened
-            doc.fileURL = folder.appendingPathComponent("Saved.txt")
-            let panel = NSSavePanel()
-            let defaultDirectory = panel.directoryURL
-
-            XCTAssertTrue(doc.prepareSavePanel(panel))
-
-            XCTAssertEqual(panel.directoryURL, defaultDirectory,
-                           "Save As on a saved template should behave like any other document")
-        }
-    }
-
-    func testOrdinaryDocumentSavePanelUntouched() throws {
-        let doc = Document()
-        let panel = NSSavePanel()
-        let defaultDirectory = panel.directoryURL
-
-        XCTAssertTrue(doc.prepareSavePanel(panel))
-
-        XCTAssertEqual(panel.directoryURL, defaultDirectory)
-        XCTAssertTrue(panel.allowedContentTypes.isEmpty)
-    }
-
-    /// Closing an untouched Create New Template window must not prompt
-    /// to save nothing; a seeded snippet draft has real content and must.
-    func testAuthoringDocumentEditedOnlyWhenSeeded() throws {
-        try withTemplateFolder { folder in
-            let empty = Document.makeAuthoringDocument(withText: "", steeredTo: folder)
-            defer { empty.close() }
-            let seeded = Document.makeAuthoringDocument(withText: "starter", steeredTo: folder)
-            defer { seeded.close() }
-
-            XCTAssertFalse(empty.isDocumentEdited)
-            XCTAssertTrue(seeded.isDocumentEdited)
-            XCTAssertEqual(seeded.text, "starter")
-        }
-    }
-
     // MARK: - Input size guard (#239)
 
     /// One byte past the limit — the guard checks size before any bytes

--- a/JotTests/FolderMenuSourceTests.swift
+++ b/JotTests/FolderMenuSourceTests.swift
@@ -23,9 +23,9 @@ final class FolderMenuSourceTests: XCTestCase {
                          emptyTitle: "No Templates",
                          selectionAction: #selector(selectItem(_:)),
                          selectionTarget: self,
-                         openFolderTitle: "Open Templates Folder",
-                         openFolderAction: #selector(openFolder(_:)),
-                         openFolderTarget: self)
+                         trailingItems: [.init(title: "Open Templates Folder",
+                                               action: #selector(openFolder(_:)))],
+                         trailingTarget: self)
     }
 
     /// selectionTarget nil means responder-chain dispatch (#162); the
@@ -36,9 +36,9 @@ final class FolderMenuSourceTests: XCTestCase {
                          emptyTitle: "No Snippets",
                          selectionAction: #selector(selectItem(_:)),
                          selectionTarget: nil,
-                         openFolderTitle: "Open Snippets Folder",
-                         openFolderAction: #selector(openFolder(_:)),
-                         openFolderTarget: self)
+                         trailingItems: [.init(title: "Open Snippets Folder",
+                                               action: #selector(openFolder(_:)))],
+                         trailingTarget: self)
     }
 
     /// Runs `body` with a fresh temp directory that is removed afterward.
@@ -215,6 +215,70 @@ final class FolderMenuSourceTests: XCTestCase {
             XCTAssertEqual(menu.items[0].action, #selector(selectItem(_:)))
             // Open-folder item keeps its concrete target
             XCTAssertTrue(menu.items[2].target === self)
+        }
+    }
+
+    func testMenuListsTrailingItemsInOrder() throws {
+        try withTempFolder { folder in
+            let source = FolderMenuSource(
+                folder: folder,
+                fileExtensions: ["txt", "md"],
+                emptyTitle: "No Templates",
+                selectionAction: #selector(selectItem(_:)),
+                selectionTarget: self,
+                trailingItems: [
+                    .init(title: "Create New Template…", action: #selector(selectItem(_:))),
+                    .init(title: "Open Templates Folder", action: #selector(openFolder(_:))),
+                ],
+                trailingTarget: self)
+            let menu = NSMenu()
+
+            source.menuNeedsUpdate(menu)
+
+            // empty state + separator + two trailing items
+            XCTAssertEqual(menu.items.count, 4)
+            XCTAssertEqual(menu.items[2].title, "Create New Template…")
+            XCTAssertEqual(menu.items[3].title, "Open Templates Folder")
+            XCTAssertTrue(menu.items[2].target === self)
+            XCTAssertTrue(menu.items[3].target === self)
+        }
+    }
+
+    // MARK: - badgeLabel (#233, #238)
+
+    func testBadgeLabelForTemplatesAndSnippetsFolders() throws {
+        try withTempFolder { templates in
+            try withTempFolder { snippets in
+                let inTemplates = templates.appendingPathComponent("Meeting.md")
+                let inSnippets = snippets.appendingPathComponent("Sig.txt")
+                let elsewhere = FileManager.default.temporaryDirectory.appendingPathComponent("Plain.txt")
+
+                XCTAssertEqual(FolderMenuSource.badgeLabel(for: inTemplates,
+                                                           templatesFolder: templates,
+                                                           snippetsFolder: snippets), "TEMPLATE")
+                XCTAssertEqual(FolderMenuSource.badgeLabel(for: inSnippets,
+                                                           templatesFolder: templates,
+                                                           snippetsFolder: snippets), "SNIPPET")
+                XCTAssertNil(FolderMenuSource.badgeLabel(for: elsewhere,
+                                                         templatesFolder: templates,
+                                                         snippetsFolder: snippets))
+                XCTAssertNil(FolderMenuSource.badgeLabel(for: nil,
+                                                         templatesFolder: templates,
+                                                         snippetsFolder: snippets))
+            }
+        }
+    }
+
+    /// A file in a subfolder of Templates is not a template — the menu
+    /// scan is not recursive, so the badge must not claim it either.
+    func testBadgeLabelIgnoresSubfolders() throws {
+        try withTempFolder { templates in
+            let nested = templates.appendingPathComponent("Sub", isDirectory: true)
+                .appendingPathComponent("Deep.md")
+
+            XCTAssertNil(FolderMenuSource.badgeLabel(for: nested,
+                                                     templatesFolder: templates,
+                                                     snippetsFolder: nil))
         }
     }
 

--- a/JotTests/FolderMenuSourceTests.swift
+++ b/JotTests/FolderMenuSourceTests.swift
@@ -244,6 +244,34 @@ final class FolderMenuSourceTests: XCTestCase {
         }
     }
 
+    // MARK: - authoringFileName (#233, #238)
+
+    func testAuthoringFileNameDefaultsToTxt() {
+        XCTAssertEqual(FolderMenuSource.authoringFileName(from: "Meeting Notes"), "Meeting Notes.txt")
+    }
+
+    func testAuthoringFileNameKeepsListedExtensions() {
+        XCTAssertEqual(FolderMenuSource.authoringFileName(from: "Blog Post.md"), "Blog Post.md")
+        XCTAssertEqual(FolderMenuSource.authoringFileName(from: "Sig.TXT"), "Sig.TXT")
+    }
+
+    /// .markdown is a valid extension for opening, but the submenus only
+    /// scan for txt and md — a kept .markdown would create an invisible
+    /// file, so it gets .txt appended like any other unlisted suffix.
+    func testAuthoringFileNameAppendsTxtToUnlistedExtensions() {
+        XCTAssertEqual(FolderMenuSource.authoringFileName(from: "Notes.markdown"), "Notes.markdown.txt")
+        XCTAssertEqual(FolderMenuSource.authoringFileName(from: "Notes.pdf"), "Notes.pdf.txt")
+    }
+
+    func testAuthoringFileNameSanitizesPathCharacters() {
+        XCTAssertEqual(FolderMenuSource.authoringFileName(from: "a/b:c"), "a-b-c.txt")
+    }
+
+    func testAuthoringFileNameNilForBlankInput() {
+        XCTAssertNil(FolderMenuSource.authoringFileName(from: ""))
+        XCTAssertNil(FolderMenuSource.authoringFileName(from: "   \n"))
+    }
+
     // MARK: - badgeLabel (#233, #238)
 
     func testBadgeLabelForTemplatesAndSnippetsFolders() throws {


### PR DESCRIPTION
## Summary

Implements #233 (Create New Template… + TEMPLATE badge) and #238 (Create New Snippet… + SNIPPET badge, seeded starter text) — the last two feature issues of Content and Capture. Two commits: the feature as designed, then a mechanism replacement forced by a platform discovery mid-testing.

### Creation affordance

- `FolderMenuSource`'s single "Open … Folder" slot generalizes to a list of trailing items; both submenus now end with "Create New …" / "Open … Folder".
- **The steered save panel (#233's Option A) proved impossible, not just fragile**: the powerbox refuses to point a save panel inside the sandbox container, by design (Apple forums thread 119987 — "it won't be fixed - ever"). Discovered when Brian's testing showed the panel opening at the last-used location.
- Replacement (decided with Brian): a **name-first dialog**. Create New asks for a name, writes the file directly into the folder — full rights inside our own container, no panel involved — and opens it saved-in-place. The file appears in the submenu immediately, autosave-in-place persists edits, and nothing can be silently stranded elsewhere.
- Name handling is one pure function (`FolderMenuSource.authoringFileName`): typed `.txt`/`.md` kept (exactly what the submenus scan for), anything else gets `.txt`, slashes and colons become dashes, blank cancels. Collisions fail with the stock "already exists" error via `withoutOverwriting`.
- New snippets are seeded with starter text naming `{{date}}`, `{{time}}`, `{{cursor}}` — the variables' only in-app documentation. Wording is placeholder pending Brian's content pass (`AppDelegate.snippetStarterText`), as is the dialog copy.

### Folder badge

A quiet `TEMPLATE` / `SNIPPET` label in the status bar next to the encoding indicator when the document's `fileURL` parent is the corresponding folder — tells editing a master apart from editing an untitled copy. Standardized-path comparison (subfolders excluded), updated on appearance and via KVO on `fileURL` so Save As / Duplicate / Rename re-badge. Worst case is a missing badge, never a wrong one. Window-title prefix was considered and rejected in #233.

## Testing

- 368 tests green locally after a clean build; 12 new across the two commits (trailing-item order, badge detection incl. subfolder exclusion, filename normalization).
- Manually verified by Brian: creation flow, badges, .md mode steering, collision error, autosave persistence.

Refs #233, #238 (close manually after merge — PRs target develop)

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H9Asj7Vqhs5hoB1nVs6Se4
