### PR TITLE
test: isolate preference tests from real UserDefaults (#174)

### DIFF
--- a/Jot/Models/PreferencesManager.swift
+++ b/Jot/Models/PreferencesManager.swift
@@ -14,9 +14,17 @@ import Cocoa
 class PreferencesManager {
 
     static let shared = PreferencesManager()
-    private init() {}
 
-    private let defaults = UserDefaults.standard
+    /// The backing store. Injectable so tests run against a throwaway
+    /// suite instead of the developer's real preferences (#174). `var`
+    /// rather than `let` solely so integration tests that must go
+    /// through the shared singleton can repoint it for a test's
+    /// duration — app code never reassigns it.
+    var defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
 
     // MARK: - Keys
 

--- a/JotTests/FontBroadcastTests.swift
+++ b/JotTests/FontBroadcastTests.swift
@@ -14,22 +14,29 @@ import XCTest
 @MainActor
 final class FontBroadcastTests: XCTestCase {
 
-	// FontConfiguration persists through UserDefaults.standard. Each test
-	// wraps itself in this so the developer's real preferences survive;
-	// no stored fixtures — XCTest's setUp is nonisolated under Swift 6
-	// (same reasoning as EditorFormattingTests).
+	// Repoints the shared PreferencesManager at a throwaway suite for
+	// the test's duration (#174): the developer's real preferences are
+	// never written, even if the run dies mid-test — unlike the old
+	// save/restore dance, whose defer did not survive a fatalError.
+	// The singleton (not an injected instance) because these are
+	// integration tests: the editors under test observe
+	// FontConfiguration.shared, which persists through
+	// PreferencesManager.shared.
 	//
-	// FontConfiguration.shared is a process-lifetime singleton, so restoring
-	// only the defaults keys would leave the in-memory font mutated for
-	// every later test in the run. currentFont is restored too.
-	private func withSavedFontPreferences(_ body: () throws -> Void) rethrows {
-		let savedFontName = PreferencesManager.shared.fontName
-		let savedFontSize = PreferencesManager.shared.fontSize
+	// FontConfiguration.shared is a process-lifetime singleton, so its
+	// in-memory font is restored too — while the throwaway is still
+	// installed, so the restore's own defaults writes land there, not
+	// in the real store.
+	private func withIsolatedFontPreferences(_ body: () throws -> Void) rethrows {
+		let suiteName = "JotTests-\(UUID().uuidString)"
+		let throwaway = UserDefaults(suiteName: suiteName)!
+		let realDefaults = PreferencesManager.shared.defaults
 		let savedFont = FontConfiguration.shared.resolvedFont()
+		PreferencesManager.shared.defaults = throwaway
 		defer {
 			FontConfiguration.shared.applyFont(savedFont)
-			PreferencesManager.shared.fontName = savedFontName
-			PreferencesManager.shared.fontSize = savedFontSize
+			PreferencesManager.shared.defaults = realDefaults
+			throwaway.removePersistentDomain(forName: suiteName)
 		}
 		// Start from a known size: several tests below decrement toward the
 		// floor or assert against the persisted value, and inheriting
@@ -57,7 +64,7 @@ final class FontBroadcastTests: XCTestCase {
 	}
 
 	func testSizeChangeReachesEveryOpenEditor() throws {
-		try withSavedFontPreferences {
+		try withIsolatedFontPreferences {
 			let (doc1, editor1) = try makeEditor()
 			defer { doc1.close() }
 			let (doc2, editor2) = try makeEditor()
@@ -72,7 +79,7 @@ final class FontBroadcastTests: XCTestCase {
 	}
 
 	func testSizeChangePersistsWithoutAnyEditorOpen() {
-		withSavedFontPreferences {
+		withIsolatedFontPreferences {
 			let newSize = FontConfiguration.shared.currentSize + 2
 			FontConfiguration.shared.applySize(newSize)
 
@@ -81,7 +88,7 @@ final class FontBroadcastTests: XCTestCase {
 	}
 
 	func testSizeOnlyChangeDoesNotPersistAFontName() {
-		withSavedFontPreferences {
+		withIsolatedFontPreferences {
 			// A user who never chose a font must not get the system font's
 			// dot-prefixed name written into preferences — NSFont(name:)
 			// round-trips those unreliably across OS versions.
@@ -93,7 +100,7 @@ final class FontBroadcastTests: XCTestCase {
 	}
 
 	func testFontChangePostsExactlyOneNotification() {
-		withSavedFontPreferences {
+		withIsolatedFontPreferences {
 			// applyFont adopts font and size together: one change, one
 			// restyle. assertForOverFulfill catches a double post.
 			let expectation = XCTNSNotificationExpectation(
@@ -110,7 +117,7 @@ final class FontBroadcastTests: XCTestCase {
 	// MARK: - Bigger/Smaller: per-window temporary zoom (#124 follow-up)
 
 	func testBiggerIsAPerWindowOverride() throws {
-		try withSavedFontPreferences {
+		try withIsolatedFontPreferences {
 			let (doc1, editor1) = try makeEditor()
 			defer { doc1.close() }
 			let (doc2, editor2) = try makeEditor()
@@ -134,7 +141,7 @@ final class FontBroadcastTests: XCTestCase {
 	}
 
 	func testActualSizeClearsTheZoom() throws {
-		try withSavedFontPreferences {
+		try withIsolatedFontPreferences {
 			let (doc, editor) = try makeEditor()
 			defer { doc.close() }
 
@@ -149,7 +156,7 @@ final class FontBroadcastTests: XCTestCase {
 	}
 
 	func testActualSizeIsDisabledWhenNotZoomed() throws {
-		try withSavedFontPreferences {
+		try withIsolatedFontPreferences {
 			let (doc, editor) = try makeEditor()
 			defer { doc.close() }
 
@@ -169,7 +176,7 @@ final class FontBroadcastTests: XCTestCase {
 	}
 
 	func testBiggerCeilingHolds() throws {
-		try withSavedFontPreferences {
+		try withIsolatedFontPreferences {
 			let (doc, editor) = try makeEditor()
 			defer { doc.close() }
 
@@ -179,7 +186,7 @@ final class FontBroadcastTests: XCTestCase {
 	}
 
 	func testSmallerFloorsAtSixPoints() throws {
-		try withSavedFontPreferences {
+		try withIsolatedFontPreferences {
 			let (doc, editor) = try makeEditor()
 			defer { doc.close() }
 
@@ -189,7 +196,7 @@ final class FontBroadcastTests: XCTestCase {
 	}
 
 	func testZoomSurvivesAStateRestorationRoundTrip() throws {
-		try withSavedFontPreferences {
+		try withIsolatedFontPreferences {
 			let (doc, editor) = try makeEditor()
 			defer { doc.close() }
 
@@ -213,7 +220,7 @@ final class FontBroadcastTests: XCTestCase {
 	}
 
 	func testSettingsChangeResetsWindowZoom() throws {
-		try withSavedFontPreferences {
+		try withIsolatedFontPreferences {
 			let (doc, editor) = try makeEditor()
 			defer { doc.close() }
 

--- a/JotTests/LineNumberGutterTests.swift
+++ b/JotTests/LineNumberGutterTests.swift
@@ -560,26 +560,36 @@ final class LineNumberGutterTests: XCTestCase {
 
     // MARK: - Preference (#106)
 
-    /// Same save/restore pattern as the font tests; #174 tracks moving
-    /// all preference tests onto an injected throwaway UserDefaults.
-    private func withSavedLineNumbersPreference(_ body: () throws -> Void) rethrows {
-        let saved = PreferencesManager.shared.showLineNumbers
-        defer { PreferencesManager.shared.showLineNumbers = saved }
+    /// Repoints the shared PreferencesManager at a throwaway suite
+    /// (#174) — same pattern as FontBroadcastTests, singleton because
+    /// the gutter integration goes through PreferencesManager.shared.
+    /// The developer's real preferences are never written, even if the
+    /// run dies mid-test.
+    private func withIsolatedPreferences(_ body: () throws -> Void) rethrows {
+        let suiteName = "JotTests-\(UUID().uuidString)"
+        let throwaway = UserDefaults(suiteName: suiteName)!
+        let realDefaults = PreferencesManager.shared.defaults
+        PreferencesManager.shared.defaults = throwaway
+        defer {
+            PreferencesManager.shared.defaults = realDefaults
+            throwaway.removePersistentDomain(forName: suiteName)
+        }
         try body()
     }
 
     func testShowLineNumbersDefaultsToOn() {
-        withSavedLineNumbersPreference {
-            UserDefaults.standard.removeObject(forKey: "showLineNumbers")
+        withIsolatedPreferences {
+            // The throwaway suite is fresh — no stored value, so this
+            // reads the coded default.
             XCTAssertTrue(PreferencesManager.shared.showLineNumbers)
         }
     }
 
     func testShowLineNumbersPersists() {
-        withSavedLineNumbersPreference {
+        withIsolatedPreferences {
             PreferencesManager.shared.showLineNumbers = false
             XCTAssertFalse(PreferencesManager.shared.showLineNumbers)
-            XCTAssertFalse(UserDefaults.standard.bool(forKey: "showLineNumbers"))
+            XCTAssertFalse(PreferencesManager.shared.defaults.bool(forKey: "showLineNumbers"))
         }
     }
 
@@ -591,7 +601,7 @@ final class LineNumberGutterTests: XCTestCase {
     }
 
     func testChangingThePreferencePostsExactlyOneNotification() {
-        withSavedLineNumbersPreference {
+        withIsolatedPreferences {
             PreferencesManager.shared.showLineNumbers = true
 
             let received = Counter()
@@ -608,7 +618,7 @@ final class LineNumberGutterTests: XCTestCase {
     func testWritingTheSameValuePostsNothing() {
         // Every editor window re-lays-out on this notification; a no-op
         // write must not fan out as a change
-        withSavedLineNumbersPreference {
+        withIsolatedPreferences {
             PreferencesManager.shared.showLineNumbers = true
 
             let received = Counter()

--- a/JotTests/PreferencesManagerTests.swift
+++ b/JotTests/PreferencesManagerTests.swift
@@ -12,29 +12,30 @@ import XCTest
 @MainActor
 final class PreferencesManagerTests: XCTestCase {
 
-    private let prefs = PreferencesManager.shared
-    private let defaults = UserDefaults.standard
+    // A fresh throwaway suite per test (#174): the developer's real
+    // preferences are never read or written, even if the run dies
+    // mid-test — the old save/restore dance depended on defer, which
+    // does not run on fatalError or a cancelled run.
+    private var suiteName = ""
+    private var defaults: UserDefaults!
 
-    // Save and restore all keys around each test to avoid polluting state.
-    private var savedFontName: Any?
-    private var savedFontSize: Any?
-    private var savedRemoteImages: Any?
+    /// Fresh instance over the throwaway suite. Computed so the
+    /// MainActor-isolated init runs inside the MainActor test body,
+    /// not in nonisolated setUp; PreferencesManager holds no state of
+    /// its own, so a new wrapper per access reads the same store.
+    private var prefs: PreferencesManager { PreferencesManager(defaults: defaults) }
 
     override func setUp() {
         super.setUp()
-        savedFontName = defaults.object(forKey: "selectedFontName")
-        savedFontSize = defaults.object(forKey: "selectedFontSize")
-        savedRemoteImages = defaults.object(forKey: "loadRemoteImages")
-
-        defaults.removeObject(forKey: "selectedFontName")
-        defaults.removeObject(forKey: "selectedFontSize")
-        defaults.removeObject(forKey: "loadRemoteImages")
+        suiteName = "JotTests-\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
     }
 
     override func tearDown() {
-        defaults.set(savedFontName, forKey: "selectedFontName")
-        defaults.set(savedFontSize, forKey: "selectedFontSize")
-        defaults.set(savedRemoteImages, forKey: "loadRemoteImages")
+        // Deletes the suite's plist from the test host container. If a
+        // crash skips this, the orphan lives in the container, not in
+        // the developer's preferences.
+        defaults.removePersistentDomain(forName: suiteName)
         super.tearDown()
     }
 
@@ -69,6 +70,16 @@ final class PreferencesManagerTests: XCTestCase {
     func testFontSizeCanBeCleared() {
         prefs.fontSize = 24
         prefs.fontSize = nil
+        XCTAssertNil(prefs.fontSize)
+    }
+
+    /// Documented quirk (#174): the getter maps a stored 0 to nil, so
+    /// the boundary is not a faithful round-trip at exactly this value.
+    /// Not reachable through the UI today — the font system never
+    /// yields a 0-point size — but if that changes, this test is the
+    /// tripwire.
+    func testFontSizeZeroReadsBackAsNil() {
+        prefs.fontSize = 0
         XCTAssertNil(prefs.fontSize)
     }
 


### PR DESCRIPTION
## Summary

Implements #174 from the Test Infrastructure milestone — pulled forward ahead of the preview work per the sequencing in `docs/issue-clusters.md`, so every test run during the heavy milestones is trustworthy.

- `PreferencesManager` gains `init(defaults: UserDefaults = .standard)`; its backing store becomes an internal `var` so integration tests can repoint the shared singleton at a throwaway UUID-named suite. The app never reassigns it.
- The crash-safety property the old save/restore dance lacked: `defer` does not run on `fatalError` or a cancelled run, so an interrupted run could leave the developer's real font preference changed. Now the real plist is never written at all — a crash's worst case is an orphan suite plist inside the test host container.
- `PreferencesManagerTests`: fresh instance over a fresh suite per test; save/restore fixture deleted; new test documents the `fontSize` 0-reads-as-nil boundary quirk from the issue.
- `FontBroadcastTests` / `LineNumberGutterTests`: helpers renamed (`withIsolatedFontPreferences` / `withIsolatedPreferences`) and now swap the singleton's store. The font helper still restores `FontConfiguration.shared`'s in-memory state (process-lifetime singleton), deliberately *before* the pointer swaps back so the restore's own writes land in the throwaway.

## Testing

369 tests green locally.

Refs #174 (close manually after merge — PRs target develop)

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H9Asj7Vqhs5hoB1nVs6Se4