### PR TITLE
feat: highlighting, footnotes, and a11y for markdown preview (#268, #269, #52)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,9 +15,9 @@ readable, obvious code beats clever code.
 
 ## Branch and release model
 
-- Work happens on `develop`. PRs target `develop`, never `main` — which
-  means GitHub never auto-closes issues from PR merges; close them
-  manually.
+- `develop` is the default branch. Work happens there. PRs target
+  `develop`, never `main` — which means GitHub never auto-closes issues
+  from PR merges; close them manually.
 - `main` mirrors the shipped App Store version and is only fast-forwarded
   to release tags (e.g. `v1.0.10`) after Apple approval. To reason about
   shipped behavior, read the release tag, not `main`.

--- a/Jot/Markdown/MarkdownHTMLRenderer.swift
+++ b/Jot/Markdown/MarkdownHTMLRenderer.swift
@@ -17,11 +17,8 @@ import Markdown
 ///
 /// Covers the CommonMark core plus the GFM extensions swift-markdown
 /// parses by default (tables, strikethrough, task lists). Highlighting
-/// (`==text==`) is post-processed because swift-markdown has no AST node
-/// for it. Footnotes (`[^1]`) are tracked in #269. Until then, footnote
-/// syntax parses as an ordinary link reference definition (`[^1]: note`
-/// yields a link to "note") -- pinned by
-/// testFootnoteSyntaxIsNotYetSupported.
+/// (`==text==`) and footnotes (`[^id]`) are post-processed because
+/// swift-markdown has no AST nodes for either.
 struct MarkdownHTMLRenderer: MarkupVisitor {
 
 	/// Parses `markdown` and returns the rendered HTML body.
@@ -34,10 +31,13 @@ struct MarkdownHTMLRenderer: MarkupVisitor {
 	/// markdown says; typographic substitution is an editor-side,
 	/// per-mode decision (#150), so smart parsing is disabled here.
 	static func render(markdown: String) -> String {
-		let document = Markdown.Document(parsing: markdown, options: .disableSmartOpts)
+		let (processedMarkdown, footnotes) = extractFootnotes(from: markdown)
+		let document = Markdown.Document(parsing: processedMarkdown, options: .disableSmartOpts)
 		var renderer = MarkdownHTMLRenderer()
-		let html = renderer.visit(document)
-		return applyHighlighting(html)
+		var html = renderer.visit(document)
+		html = applyHighlighting(html)
+		html = applyFootnotes(html, definitions: footnotes)
+		return html
 	}
 
 	// Link clicks open in the default browser (see the preview's
@@ -371,5 +371,156 @@ struct MarkdownHTMLRenderer: MarkupVisitor {
 			range: range,
 			withTemplate: "<mark>$1</mark>"
 		)
+	}
+
+	// MARK: - Footnotes ([^id])
+
+	// swift-markdown has no footnote AST nodes. Pre-processing strips
+	// definition lines and replaces inline [^id] references with text
+	// markers. The parser treats the markers as plain text (escaping
+	// them inside code spans automatically). Post-processing converts
+	// the markers outside <code>/<pre> into superscript links and
+	// appends a footnotes section.
+
+	private static let footnoteDefPattern = try! NSRegularExpression(
+		pattern: #"(?m)^\[\^([A-Za-z0-9_-]+)\]:\s+(.+)$"#
+	)
+
+	private static let footnoteRefPattern = try! NSRegularExpression(
+		pattern: #"\[\^([A-Za-z0-9_-]+)\]"#
+	)
+
+	private static let fnMarkerPrefix = "\u{FFFE}FN:"
+	private static let fnMarkerSuffix = "\u{FFFE}"
+
+	private static func extractFootnotes(from markdown: String) -> (String, [(id: String, text: String)]) {
+		let nsMarkdown = markdown as NSString
+		let fullRange = NSRange(location: 0, length: nsMarkdown.length)
+
+		var definitions: [(id: String, text: String)] = []
+		var definitionIDs: Set<String> = []
+		for match in footnoteDefPattern.matches(in: markdown, range: fullRange) {
+			let id = nsMarkdown.substring(with: match.range(at: 1))
+			let text = nsMarkdown.substring(with: match.range(at: 2))
+			if definitionIDs.insert(id).inserted {
+				definitions.append((id: id, text: text))
+			}
+		}
+
+		guard !definitions.isEmpty else { return (markdown, []) }
+
+		// Strip definition lines.
+		var processed = footnoteDefPattern.stringByReplacingMatches(
+			in: markdown, range: fullRange, withTemplate: ""
+		)
+
+		// Replace [^id] references that have definitions with markers.
+		let nsProcessed = processed as NSString
+		let procRange = NSRange(location: 0, length: nsProcessed.length)
+		let refMatches = footnoteRefPattern.matches(in: processed, range: procRange)
+		for match in refMatches.reversed() {
+			let id = nsProcessed.substring(with: match.range(at: 1))
+			guard definitionIDs.contains(id) else { continue }
+			let marker = fnMarkerPrefix + id + fnMarkerSuffix
+			processed = (processed as NSString).replacingCharacters(in: match.range, with: marker)
+		}
+
+		return (processed, definitions)
+	}
+
+	private static func applyFootnotes(_ html: String, definitions: [(id: String, text: String)]) -> String {
+		guard !definitions.isEmpty else { return html }
+
+		var indexByID: [String: Int] = [:]
+		for (i, def) in definitions.enumerated() {
+			indexByID[def.id] = i + 1
+		}
+
+		// Replace markers with superscript links, skipping code blocks.
+		let result = replaceFootnoteMarkers(in: html, indexByID: indexByID)
+
+		// Append the footnotes section.
+		var section = "<section class=\"footnotes\">\n<hr />\n<ol>\n"
+		for def in definitions {
+			let escapedText = escapeHTMLStatic(def.text)
+			section += "<li id=\"fn-\(def.id)\"><p>\(escapedText) "
+			section += "<a href=\"#fnref-\(def.id)\">&#8617;</a>"
+			section += "</p>\n</li>\n"
+		}
+		section += "</ol>\n</section>\n"
+
+		// Any remaining markers (inside code blocks, or references
+		// without definitions) revert to their original [^id] form.
+		var final = result + section
+		for id in indexByID.keys {
+			let marker = fnMarkerPrefix + id + fnMarkerSuffix
+			final = final.replacingOccurrences(of: marker, with: "[^\(id)]")
+		}
+		return final
+	}
+
+	private static func replaceFootnoteMarkers(in html: String, indexByID: [String: Int]) -> String {
+		// Walk the HTML, skipping <code>/<pre> blocks (same approach
+		// as applyHighlighting). Inside code, the parser has already
+		// escaped the marker characters, so they won't match anyway,
+		// but skipping keeps the logic explicit.
+		var result = ""
+		var searchStart = html.startIndex
+
+		while searchStart < html.endIndex {
+			let remaining = html[searchStart...]
+			let codeMatch = remaining.range(of: "<code")
+			let preMatch = remaining.range(of: "<pre>")
+
+			let nextCodeOpen: Range<String.Index>?
+			let closeTag: String
+			if let c = codeMatch, let p = preMatch {
+				if c.lowerBound <= p.lowerBound {
+					nextCodeOpen = c; closeTag = "</code>"
+				} else {
+					nextCodeOpen = p; closeTag = "</pre>"
+				}
+			} else if let c = codeMatch {
+				nextCodeOpen = c; closeTag = "</code>"
+			} else if let p = preMatch {
+				nextCodeOpen = p; closeTag = "</pre>"
+			} else {
+				nextCodeOpen = nil; closeTag = ""
+			}
+
+			guard let openRange = nextCodeOpen else {
+				result += replaceMarkers(in: String(remaining), indexByID: indexByID)
+				break
+			}
+
+			result += replaceMarkers(in: String(html[searchStart..<openRange.lowerBound]), indexByID: indexByID)
+
+			if let closeRange = html[openRange.upperBound...].range(of: closeTag) {
+				result += String(html[openRange.lowerBound..<closeRange.upperBound])
+				searchStart = closeRange.upperBound
+			} else {
+				result += String(html[openRange.lowerBound...])
+				break
+			}
+		}
+
+		return result
+	}
+
+	private static func replaceMarkers(in text: String, indexByID: [String: Int]) -> String {
+		var result = text
+		for (id, index) in indexByID {
+			let marker = fnMarkerPrefix + id + fnMarkerSuffix
+			let sup = "<sup><a href=\"#fn-\(id)\" id=\"fnref-\(id)\">\(index)</a></sup>"
+			result = result.replacingOccurrences(of: marker, with: sup)
+		}
+		return result
+	}
+
+	private static func escapeHTMLStatic(_ text: String) -> String {
+		text.replacingOccurrences(of: "&", with: "&amp;")
+			.replacingOccurrences(of: "<", with: "&lt;")
+			.replacingOccurrences(of: ">", with: "&gt;")
+			.replacingOccurrences(of: "\"", with: "&quot;")
 	}
 }

--- a/Jot/Markdown/MarkdownHTMLRenderer.swift
+++ b/Jot/Markdown/MarkdownHTMLRenderer.swift
@@ -17,10 +17,11 @@ import Markdown
 ///
 /// Covers the CommonMark core plus the GFM extensions swift-markdown
 /// parses by default (tables, strikethrough, task lists). Highlighting
-/// (`==text==`) and footnotes (`[^1]`) are custom extensions tracked
-/// separately in #39. Until then, footnote syntax parses as an ordinary
-/// link reference definition (`[^1]: note` yields a link to "note") --
-/// pinned by testFootnoteSyntaxIsNotYetSupported.
+/// (`==text==`) is post-processed because swift-markdown has no AST node
+/// for it. Footnotes (`[^1]`) are tracked in #269. Until then, footnote
+/// syntax parses as an ordinary link reference definition (`[^1]: note`
+/// yields a link to "note") -- pinned by
+/// testFootnoteSyntaxIsNotYetSupported.
 struct MarkdownHTMLRenderer: MarkupVisitor {
 
 	/// Parses `markdown` and returns the rendered HTML body.
@@ -35,7 +36,8 @@ struct MarkdownHTMLRenderer: MarkupVisitor {
 	static func render(markdown: String) -> String {
 		let document = Markdown.Document(parsing: markdown, options: .disableSmartOpts)
 		var renderer = MarkdownHTMLRenderer()
-		return renderer.visit(document)
+		let html = renderer.visit(document)
+		return applyHighlighting(html)
 	}
 
 	// Link clicks open in the default browser (see the preview's
@@ -300,5 +302,74 @@ struct MarkdownHTMLRenderer: MarkupVisitor {
 			return Self.allowedDataImagePrefixes.contains { lowered.hasPrefix($0) }
 		}
 		return isAllowed(source, schemes: Self.allowedImageSchemes)
+	}
+
+	// MARK: - Highlighting (==text==)
+
+	// swift-markdown has no Highlight AST node, so ==text== passes
+	// through the visitor as literal text. This post-processes the
+	// rendered HTML to convert it to <mark> tags, skipping code blocks
+	// and inline code where the delimiters should stay literal.
+	private static let highlightPattern = try! NSRegularExpression(
+		pattern: "==([^=].*?)==",
+		options: []
+	)
+
+	private static func applyHighlighting(_ html: String) -> String {
+		var result = ""
+		var searchStart = html.startIndex
+
+		while searchStart < html.endIndex {
+			let remaining = html[searchStart...]
+
+			// Find the next <code or <pre> tag.
+			let codeMatch = remaining.range(of: "<code")
+			let preMatch = remaining.range(of: "<pre>")
+
+			// Pick whichever comes first.
+			let nextCodeOpen: Range<String.Index>?
+			let closeTag: String
+			if let c = codeMatch, let p = preMatch {
+				if c.lowerBound <= p.lowerBound {
+					nextCodeOpen = c; closeTag = "</code>"
+				} else {
+					nextCodeOpen = p; closeTag = "</pre>"
+				}
+			} else if let c = codeMatch {
+				nextCodeOpen = c; closeTag = "</code>"
+			} else if let p = preMatch {
+				nextCodeOpen = p; closeTag = "</pre>"
+			} else {
+				nextCodeOpen = nil; closeTag = ""
+			}
+
+			guard let openRange = nextCodeOpen else {
+				result += replaceHighlights(in: String(remaining))
+				break
+			}
+
+			// Process everything before the code block.
+			result += replaceHighlights(in: String(html[searchStart..<openRange.lowerBound]))
+
+			// Find the matching close tag and pass the code block through unchanged.
+			if let closeRange = html[openRange.upperBound...].range(of: closeTag) {
+				result += String(html[openRange.lowerBound..<closeRange.upperBound])
+				searchStart = closeRange.upperBound
+			} else {
+				result += String(html[openRange.lowerBound...])
+				break
+			}
+		}
+
+		return result
+	}
+
+	private static func replaceHighlights(in text: String) -> String {
+		let range = NSRange(text.startIndex..., in: text)
+		return highlightPattern.stringByReplacingMatches(
+			in: text,
+			range: range,
+			withTemplate: "<mark>$1</mark>"
+		)
 	}
 }

--- a/Jot/Markdown/MarkdownHTMLRenderer.swift
+++ b/Jot/Markdown/MarkdownHTMLRenderer.swift
@@ -440,11 +440,11 @@ struct MarkdownHTMLRenderer: MarkupVisitor {
 		let result = replaceFootnoteMarkers(in: html, indexByID: indexByID)
 
 		// Append the footnotes section.
-		var section = "<section class=\"footnotes\">\n<hr />\n<ol>\n"
+		var section = "<section class=\"footnotes\" role=\"doc-endnotes\" aria-label=\"Footnotes\">\n<hr />\n<ol>\n"
 		for def in definitions {
 			let escapedText = escapeHTMLStatic(def.text)
 			section += "<li id=\"fn-\(def.id)\"><p>\(escapedText) "
-			section += "<a href=\"#fnref-\(def.id)\">&#8617;</a>"
+			section += "<a href=\"#fnref-\(def.id)\" role=\"doc-backlink\">&#8617;</a>"
 			section += "</p>\n</li>\n"
 		}
 		section += "</ol>\n</section>\n"
@@ -511,7 +511,7 @@ struct MarkdownHTMLRenderer: MarkupVisitor {
 		var result = text
 		for (id, index) in indexByID {
 			let marker = fnMarkerPrefix + id + fnMarkerSuffix
-			let sup = "<sup><a href=\"#fn-\(id)\" id=\"fnref-\(id)\">\(index)</a></sup>"
+			let sup = "<sup><a href=\"#fn-\(id)\" id=\"fnref-\(id)\" role=\"doc-noteref\">\(index)</a></sup>"
 			result = result.replacingOccurrences(of: marker, with: sup)
 		}
 		return result

--- a/Jot/Markdown/PreviewShell.swift
+++ b/Jot/Markdown/PreviewShell.swift
@@ -41,6 +41,7 @@ enum PreviewShell {
 		<html lang="\(sanitizeLanguageTag(languageTag))">
 		<head>
 		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, initial-scale=1">
 		<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; \(imgSrc);">
 		<meta name="color-scheme" content="light dark">
 		<title>\(escapeHTML(title))</title>

--- a/Jot/Markdown/PreviewTheme.swift
+++ b/Jot/Markdown/PreviewTheme.swift
@@ -137,6 +137,36 @@ struct PreviewTheme {
 		.footnotes li { margin: 0.25em 0; }
 		.footnotes p { margin: 0; display: inline; }
 
+		@media (prefers-contrast: increase) {
+			:root {
+				--fg: #000000;
+				--bg: #ffffff;
+				--muted: #000000;
+				--accent: #0000ee;
+				--rule: #000000;
+				--table-border: #000000;
+				--code-bg: #f0f0f0;
+			}
+			a { text-decoration: underline; }
+			mark { background: #ffff00; color: #000000; }
+		}
+		@media (prefers-contrast: increase) and (prefers-color-scheme: dark) {
+			:root {
+				--fg: #ffffff;
+				--bg: #000000;
+				--muted: #ffffff;
+				--accent: #ffff00;
+				--rule: #ffffff;
+				--table-border: #ffffff;
+				--code-bg: #1a1a1a;
+			}
+			mark { background: #806600; color: #ffffff; }
+		}
+
+		@media (prefers-reduced-motion: reduce) {
+			* { transition: none !important; animation: none !important; }
+		}
+
 		@media print {
 			/* Force the light palette: print strips backgrounds by
 			   default, which would leave dark mode's light text invisible

--- a/Jot/Markdown/PreviewTheme.swift
+++ b/Jot/Markdown/PreviewTheme.swift
@@ -118,6 +118,16 @@ struct PreviewTheme {
 		th { font-weight: 600; }
 		tbody tr:nth-child(2n) { background: var(--code-bg); }
 
+		mark {
+			background: #fff8c5;
+			color: var(--fg);
+			padding: 0.1em 0.2em;
+			border-radius: 3px;
+		}
+		@media (prefers-color-scheme: dark) {
+			mark { background: #4d3a0a; }
+		}
+
 		img { max-width: 100%; }
 
 		hr { border: 0; border-top: 2px solid var(--rule); margin: 1.5em 0; }
@@ -141,6 +151,7 @@ struct PreviewTheme {
 			   blocks delineated; wrapping beats clipping long lines on
 			   paper. */
 			pre { border: 1px solid var(--rule); white-space: pre-wrap; }
+			mark { background: #fff8c5; }
 			h1, h2, h3, h4 { break-after: avoid; }
 		}
 		""")

--- a/Jot/Markdown/PreviewTheme.swift
+++ b/Jot/Markdown/PreviewTheme.swift
@@ -132,6 +132,11 @@ struct PreviewTheme {
 
 		hr { border: 0; border-top: 2px solid var(--rule); margin: 1.5em 0; }
 
+		.footnotes { font-size: 0.875em; color: var(--muted); margin-top: 2em; }
+		.footnotes ol { padding-left: 1.5em; }
+		.footnotes li { margin: 0.25em 0; }
+		.footnotes p { margin: 0; display: inline; }
+
 		@media print {
 			/* Force the light palette: print strips backgrounds by
 			   default, which would leave dark mode's light text invisible

--- a/JotTests/MarkdownHTMLRendererTests.swift
+++ b/JotTests/MarkdownHTMLRendererTests.swift
@@ -255,14 +255,55 @@ final class MarkdownHTMLRendererTests: XCTestCase {
 		XCTAssertFalse(html.contains("<mark>"))
 	}
 
-	// MARK: - Footnotes (not yet supported)
+	// MARK: - Footnotes ([^id])
 
-	func testFootnoteSyntaxIsNotYetSupported() {
-		// No footnote extension in swift-markdown 0.8.0: [^1] parses as
-		// a link reference definition. Real footnotes are #39; this pins
-		// the interim behavior so #39 starts from a known state.
-		XCTAssertEqual(render("text[^1]\n\n[^1]: note"),
-					   "<p>text<a href=\"note\">^1</a></p>\n")
+	func testFootnoteRendersAsSuperscriptAndSection() {
+		let html = render("text[^1]\n\n[^1]: This is a footnote")
+		XCTAssertTrue(html.contains("<sup><a href=\"#fn-1\" id=\"fnref-1\">1</a></sup>"))
+		XCTAssertTrue(html.contains("<li id=\"fn-1\"><p>This is a footnote"))
+		XCTAssertTrue(html.contains("<a href=\"#fnref-1\">&#8617;</a>"))
+	}
+
+	func testFootnoteMultiple() {
+		let html = render("first[^a] second[^b]\n\n[^a]: Note A\n[^b]: Note B")
+		XCTAssertTrue(html.contains("<sup><a href=\"#fn-a\" id=\"fnref-a\">1</a></sup>"))
+		XCTAssertTrue(html.contains("<sup><a href=\"#fn-b\" id=\"fnref-b\">2</a></sup>"))
+		XCTAssertTrue(html.contains("<li id=\"fn-a\">"))
+		XCTAssertTrue(html.contains("<li id=\"fn-b\">"))
+	}
+
+	func testFootnoteWithoutDefinitionStaysLiteral() {
+		let html = render("text[^missing]")
+		XCTAssertFalse(html.contains("<sup>"))
+		XCTAssertFalse(html.contains("footnotes"))
+	}
+
+	func testFootnoteDefinitionTextIsEscaped() {
+		let html = render("text[^1]\n\n[^1]: <script>alert(1)</script>")
+		XCTAssertFalse(html.contains("<script>"))
+		XCTAssertTrue(html.contains("&lt;script&gt;"))
+	}
+
+	func testFootnoteInsideCodeStaysLiteral() {
+		let html = render("`[^1]`\n\n[^1]: note")
+		XCTAssertTrue(html.contains("<code>[^1]</code>"))
+		XCTAssertFalse(html.contains("<sup>"))
+	}
+
+	func testFootnoteInFencedCodeStaysLiteral() {
+		let html = render("```\n[^1]\n```\n\n[^1]: note")
+		XCTAssertFalse(html.contains("<sup>"))
+	}
+
+	func testFootnoteBacklinkExists() {
+		let html = render("text[^1]\n\n[^1]: note")
+		XCTAssertTrue(html.contains("&#8617;"))
+		XCTAssertTrue(html.contains("href=\"#fnref-1\""))
+	}
+
+	func testFootnoteSectionIsAtEnd() {
+		let html = render("paragraph\n\ntext[^1]\n\n[^1]: note")
+		XCTAssertTrue(html.hasSuffix("</section>\n"))
 	}
 
 	// MARK: - Security: data: image hardening

--- a/JotTests/MarkdownHTMLRendererTests.swift
+++ b/JotTests/MarkdownHTMLRendererTests.swift
@@ -259,15 +259,15 @@ final class MarkdownHTMLRendererTests: XCTestCase {
 
 	func testFootnoteRendersAsSuperscriptAndSection() {
 		let html = render("text[^1]\n\n[^1]: This is a footnote")
-		XCTAssertTrue(html.contains("<sup><a href=\"#fn-1\" id=\"fnref-1\">1</a></sup>"))
+		XCTAssertTrue(html.contains("<sup><a href=\"#fn-1\" id=\"fnref-1\" role=\"doc-noteref\">1</a></sup>"))
 		XCTAssertTrue(html.contains("<li id=\"fn-1\"><p>This is a footnote"))
-		XCTAssertTrue(html.contains("<a href=\"#fnref-1\">&#8617;</a>"))
+		XCTAssertTrue(html.contains("<a href=\"#fnref-1\" role=\"doc-backlink\">&#8617;</a>"))
 	}
 
 	func testFootnoteMultiple() {
 		let html = render("first[^a] second[^b]\n\n[^a]: Note A\n[^b]: Note B")
-		XCTAssertTrue(html.contains("<sup><a href=\"#fn-a\" id=\"fnref-a\">1</a></sup>"))
-		XCTAssertTrue(html.contains("<sup><a href=\"#fn-b\" id=\"fnref-b\">2</a></sup>"))
+		XCTAssertTrue(html.contains("<sup><a href=\"#fn-a\" id=\"fnref-a\" role=\"doc-noteref\">1</a></sup>"))
+		XCTAssertTrue(html.contains("<sup><a href=\"#fn-b\" id=\"fnref-b\" role=\"doc-noteref\">2</a></sup>"))
 		XCTAssertTrue(html.contains("<li id=\"fn-a\">"))
 		XCTAssertTrue(html.contains("<li id=\"fn-b\">"))
 	}
@@ -304,6 +304,21 @@ final class MarkdownHTMLRendererTests: XCTestCase {
 	func testFootnoteSectionIsAtEnd() {
 		let html = render("paragraph\n\ntext[^1]\n\n[^1]: note")
 		XCTAssertTrue(html.hasSuffix("</section>\n"))
+	}
+
+	func testFootnoteSectionHasAriaLabel() {
+		let html = render("text[^1]\n\n[^1]: note")
+		XCTAssertTrue(html.contains("<section class=\"footnotes\" role=\"doc-endnotes\" aria-label=\"Footnotes\">"))
+	}
+
+	func testFootnoteRefHasNoterefRole() {
+		let html = render("text[^1]\n\n[^1]: note")
+		XCTAssertTrue(html.contains("role=\"doc-noteref\""))
+	}
+
+	func testFootnoteBacklinkHasBacklinkRole() {
+		let html = render("text[^1]\n\n[^1]: note")
+		XCTAssertTrue(html.contains("role=\"doc-backlink\""))
 	}
 
 	// MARK: - Security: data: image hardening

--- a/JotTests/MarkdownHTMLRendererTests.swift
+++ b/JotTests/MarkdownHTMLRendererTests.swift
@@ -212,6 +212,51 @@ final class MarkdownHTMLRendererTests: XCTestCase {
 		XCTAssertTrue(html.contains("x"))
 	}
 
+	// MARK: - Highlighting (==text==)
+
+	func testHighlightRendersAsMark() {
+		XCTAssertEqual(render("==highlighted=="), "<p><mark>highlighted</mark></p>\n")
+	}
+
+	func testHighlightWithSurroundingText() {
+		XCTAssertEqual(render("before ==highlighted== after"),
+					   "<p>before <mark>highlighted</mark> after</p>\n")
+	}
+
+	func testMultipleHighlightsInOneParagraph() {
+		let html = render("==one== and ==two==")
+		XCTAssertEqual(html, "<p><mark>one</mark> and <mark>two</mark></p>\n")
+	}
+
+	func testHighlightInsideInlineCodeStaysLiteral() {
+		let html = render("`==not highlighted==`")
+		XCTAssertTrue(html.contains("<code>==not highlighted==</code>"))
+		XCTAssertFalse(html.contains("<mark>"))
+	}
+
+	func testHighlightInsideFencedCodeBlockStaysLiteral() {
+		let html = render("```\n==not highlighted==\n```")
+		XCTAssertTrue(html.contains("==not highlighted=="))
+		XCTAssertFalse(html.contains("<mark>"))
+	}
+
+	func testHighlightCanCombineWithOtherInlines() {
+		let html = render("**==bold and highlighted==**")
+		XCTAssertTrue(html.contains("<strong><mark>bold and highlighted</mark></strong>"))
+	}
+
+	func testHighlightDoesNotMatchSingleEquals() {
+		let html = render("a = b = c")
+		XCTAssertFalse(html.contains("<mark>"))
+	}
+
+	func testHighlightDoesNotMatchEmpty() {
+		let html = render("====")
+		XCTAssertFalse(html.contains("<mark>"))
+	}
+
+	// MARK: - Footnotes (not yet supported)
+
 	func testFootnoteSyntaxIsNotYetSupported() {
 		// No footnote extension in swift-markdown 0.8.0: [^1] parses as
 		// a link reference definition. Real footnotes are #39; this pins

--- a/JotTests/PreviewShellTests.swift
+++ b/JotTests/PreviewShellTests.swift
@@ -55,6 +55,11 @@ final class PreviewShellTests: XCTestCase {
 		}
 	}
 
+	func testViewportMetaTagIsEmitted() {
+		XCTAssertTrue(makeDocument().contains(
+			"<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">"))
+	}
+
 	func testDeclaresBothColorSchemes() {
 		XCTAssertTrue(makeDocument().contains(
 			"<meta name=\"color-scheme\" content=\"light dark\">"))
@@ -104,5 +109,15 @@ final class PreviewShellTests: XCTestCase {
 		XCTAssertTrue(css.contains("@media (prefers-color-scheme: dark)"))
 		XCTAssertTrue(css.contains("@media print"))
 		XCTAssertTrue(css.contains("color-scheme: light dark"))
+	}
+
+	func testStandardThemeIncludesHighContrastMediaQuery() {
+		let css = PreviewTheme.standard.css
+		XCTAssertTrue(css.contains("@media (prefers-contrast: increase)"))
+	}
+
+	func testStandardThemeIncludesReducedMotionMediaQuery() {
+		let css = PreviewTheme.standard.css
+		XCTAssertTrue(css.contains("@media (prefers-reduced-motion: reduce)"))
 	}
 }


### PR DESCRIPTION
## Summary

Follow-up work on the preview rebuild branch: extended markdown constructs and accessibility.

- **Highlighting (#268)**: render `==text==` as `<mark>` via HTML post-processing (swift-markdown has no highlight AST node). Skips code blocks. CSS in both light/dark themes plus print.
- **Footnotes (#269)**: render `[^id]` references as superscript links with a footnotes section and backlinks. Pre-processes raw markdown to extract definitions and neutralize references, post-processes HTML to insert the rendered output. Code block protection via marker reversion.
- **Accessibility (#52)**: viewport meta tag, `prefers-contrast: increase` media queries (light and dark high-contrast palettes), `prefers-reduced-motion: reduce`, ARIA roles on footnotes (`doc-endnotes`, `doc-noteref`, `doc-backlink`).
- **Docs**: note that `develop` is the default branch in CLAUDE.md.

## Commits

- `8221803` docs: note that develop is the default branch (#38)
- `db86319` feat: render ==highlighted== text as `<mark>` in preview (#268)
- `a2fec89` feat: render footnotes [^id] in preview (#269)
- `8edb71f` fix(a11y): add accessibility support to markdown preview HTML (#52)

## Test plan

- [x] ==highlighted== renders as yellow `<mark>` in light and dark mode
- [x] ==text== inside inline code and fenced code blocks stays literal
- [x] Footnotes render as superscript links with backlinks
- [x] Footnotes inside code blocks stay literal
- [x] Footnote definition text is HTML-escaped (XSS protection)
- [x] High-contrast mode applies maximum contrast palette
- [x] ARIA roles present on footnote elements
- [x] 462 tests pass, 0 failures
